### PR TITLE
Galaxy job readiness probe

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -58,8 +58,17 @@ spec:
 {{- end }}
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
-          command: ["python", "/galaxy/server/scripts/galaxy-main"]
-          args: ["-c", "/galaxy/server/config/galaxy.yml", "--server-name", "$(POD_NAME)", "--attach-to-pool", "job-handlers"]
+#          command: ["python", "/galaxy/server/scripts/galaxy-main"]
+          command: ["/bin/bash", "-c", "python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name $(POD_NAME) --attach-to-pool job-handlers 2>&1 | tee /tmp/log"]
+#          args: ["-c", "/galaxy/server/config/galaxy.yml", "--server-name", "$(POD_NAME)", "--attach-to-pool", "job-handlers"]
+          readinessProbe:
+            exec:
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "tail -n 10 /tmp/log | grep \"is running\""
+#            initialDelaySeconds: 30
+#            periodSeconds: 15
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -58,17 +58,13 @@ spec:
 {{- end }}
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
-#          command: ["python", "/galaxy/server/scripts/galaxy-main"]
           command: ["/bin/bash", "-c", "python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name $(POD_NAME) --attach-to-pool job-handlers 2>&1 | tee /tmp/log"]
-#          args: ["-c", "/galaxy/server/config/galaxy.yml", "--server-name", "$(POD_NAME)", "--attach-to-pool", "job-handlers"]
           readinessProbe:
             exec:
               command:
                 - "/bin/bash"
                 - "-c"
                 - "tail -n 10 /tmp/log | grep \"is running\""
-#            initialDelaySeconds: 30
-#            periodSeconds: 15
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -64,7 +64,10 @@ spec:
               command:
                 - "/bin/bash"
                 - "-c"
-                - "tail -n 10 /tmp/log | grep \"is running\""
+                - "grep \"is running\" /tmp/log"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 70
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files


### PR DESCRIPTION
changed some behavior; python script for server is now executed through bash to pipe to tee which writes the output to a file, `/tmp/log`.

readiness probe checks this log for "is running", a string output when the job service is ready to accept jobs.

let me know what i can do to improve the quality of this PR