### PR TITLE
DB migration init container

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -44,6 +44,20 @@ spec:
               subPath: config
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}
+        - name: {{ .Chart.Name }}-db-migrations
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ['sh', '-c', '/galaxy/server/manage_db.sh upgrade']
+          volumeMounts:
+            {{- range $key,$entry := .Values.configs }}
+            - name: galaxy-conf-files
+              mountPath: /galaxy/server/config/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
+            {{- range $key,$entry := .Values.jobs.rules }}
+            - name: galaxy-job-rules
+              mountPath: /galaxy/server/lib/galaxy/jobs/rules/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
         {{- if .Values.extraInitContainers -}}
         {{- range $each := .Values.extraInitContainers -}}
         {{- if $each.applyToJob -}}


### PR DESCRIPTION
Adding a single init container in job pod for the database migration.
This works, but some things to still consider:
-Is it a problem if two pods are running the migration script in parallel: eg. when starting with 2 job pods
-The web pods will fail and restart until the migration is done. A better alternative would be to incorporate the waiting into the init container already waiting for postgres to come up, to wait for the correct version of the database