### PR TITLE
19.09 working

### DIFF
--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "v19.05"
+appVersion: "v19.09"
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 name: galaxy
-version: 3.0.0
+version: 3.1.0

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -93,5 +93,5 @@ Return galaxy database user password
 Creates the bash command for the init containers used to place files and change permissions in the galaxy pods
 */}}
 {{- define "galaxy.init-container-commands" -}}
-{{- tpl "install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt" $}}
+{{- tpl "if [ ! -f \"/galaxy/server/config/integrated_tool_panel.xml \" ]; then install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; fi; if [ ! -f \"/galaxy/server/config/sanitize_whitelist.txt \" ]; then install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt; fi" $}}
 {{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -93,5 +93,5 @@ Return galaxy database user password
 Creates the bash command for the init containers used to place files and change permissions in the galaxy pods
 */}}
 {{- define "galaxy.init-container-commands" -}}
-{{- tpl "install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt; if [ ! -f \"{{ .Values.persistence.mountPath }}/config/editable_shed_tool_conf.xml\" ]; then install -D -o 101 -g 101 /galaxy/server/config/shed_tool_conf.xml.sample {{ .Values.persistence.mountPath }}/config/editable_shed_tool_conf.xml; fi" $}}
+{{- tpl "install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt" $}}
 {{- end -}}

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: galaxy/galaxy
-  tag: 19.05
+  tag: 19.09m
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -195,7 +195,8 @@ configs:
       database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
-      tool_config_file: "{{.Values.persistence.mountPath}}/config/editable_shed_tool_conf.xml,/galaxy/server/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
+      tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
+      shed_tool_config_file: "{{.Values.persistence.mountPath}}/config/editable_shed_tool_conf.xml"
       tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/byhand/location/tool_data_table_conf.xml"
       tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
       builds_file_path: "{{.Values.cvmfs.data.mountPath}}/managed/location/builds.txt"

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -188,12 +188,55 @@ configs:
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
       job_config_file: "/galaxy/server/config/job_conf.xml"
+      sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
+      integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
   container_resolvers_conf.xml: |
     <containers_resolvers>
       <explicit />
       <mulled />
       <build_mulled />
     </containers_resolvers>
+  sanitize_whitelist.txt: |
+    toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.6.1
+    toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.6.1.1
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.52
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.63
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.64
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.67
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.68
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.69
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72
+    toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1
+    toolshed.g2.bx.psu.edu/repos/engineson/multiqc/multiqc/1.0.0.0
+    toolshed.g2.bx.psu.edu/repos/iuc/dexseq/dexseq/1.20.1
+    toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.0.20140616.0
+    toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.0.20151222.0
+    toolshed.g2.bx.psu.edu/repos/iuc/meme_meme/meme_meme/4.11.0.0
+    toolshed.g2.bx.psu.edu/repos/iuc/meme_meme/meme_meme/4.11.0.1
+    toolshed.g2.bx.psu.edu/repos/iuc/meme_meme/meme_meme/4.11.1.0
+    toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.3.1
+    toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.5.0
+    toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6
+    toolshed.g2.bx.psu.edu/repos/iuc/prestor_abseq3/prestor_abseq3/0.5.4
+    toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/4.1.1
+    toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/4.6.3
+    toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1
+  build_sites.yml: |
+    - type: ucsc
+      file: "/cvmfs/data.galaxyproject.org/managed/location/ucsc_build_sites.txt"
+      display: [main,archaea,ucla]
+    - type: gbrowse
+      file: "/galaxy/server/tool-data/shared/gbrowse/gbrowse_build_sites.txt"
+      display: [wormbase,tair,modencode_worm,modencode_fly]
+    - type: ensembl
+      file: "/galaxy/server/tool-data/shared/ensembl/ensembl_sites.txt"
+    - type: ensembl_data_url
+      file: "/galaxy/server/tool-data/shared/ensembl/ensembl_sites_data_URL.txt"
+    - type: igv
+      file: "/galaxy/server/tool-data/shared/igv/igv_build_sites.txt.sample"
+    - type: rviewer
+      file: "/galaxy/server/tool-data/shared/rviewer/rviewer_build_sites.txt.sample"
 
 # Additional dynamic rules to map into the container.
 jobs:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: galaxy/galaxy
-  tag: 19.05
+  tag: 19.09m
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Main changes:
-Versioning + image tag to 19.09
-No more copying for editable shed tool conf (it is now set with `shed_tool_config_file` and will be created automatically)

Needs either a new DB dump or the DB migration init container: https://github.com/galaxyproject/galaxy-helm/pull/56