### PR TITLE
Dind added

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -109,7 +109,16 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        - name: dind
+          image: docker:18.05-dind
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: dind-storage
+              mountPath: /var/lib/docker
       volumes:
+        - name: dind-storage
+          emptyDir: {}
         - name: galaxy-conf-files
           {{- if .Values.useSecretConfigs }}
           secret:


### PR DESCRIPTION
This is not meant to be merged, but a useful workaround until we figure out how to automate the process of finding combinations of tools not in biocontainers.
Having a docker-in-docker container will allow the job containers to build mulled containers on-the-fly and use them when the images are not found in biocontainers.

Copy of https://github.com/galaxyproject/galaxy-helm/pull/58 made as a Draft PR.