### PR TITLE
Resource limits and ingress

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -79,7 +79,8 @@ extraEnv:
 
 ingress:
   enabled: true
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "10G"
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /galaxy

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -412,10 +412,10 @@ jobs:
           small:
             requests:
               cpu: 1
-              memory: 500m
+              memory: 2G
             limits:
               cpu: 2
-              memory: 1G
+              memory: 5G
         default_resource_set: small
     k8s_container_mapper.py: |
       {{- (.Files.Get "files/rules/k8s_container_mapper.py") }}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -46,6 +46,7 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10G"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite ^({{ .Values.ingress.path }})$ {{ .Values.ingress.path }}/ redirect;
   path: /


### PR DESCRIPTION
The default limits were too low for anything but development. Chatted with @natefoo and it seems the proposed settings are still on the low side but can hopefully allow for reasonable usage. More advanced setup we can develop in https://github.com/galaxyproject/galaxy-helm/issues/63.