### PR TITLE
Config fixes

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -93,5 +93,13 @@ Return galaxy database user password
 Creates the bash command for the init containers used to place files and change permissions in the galaxy pods
 */}}
 {{- define "galaxy.init-container-commands" -}}
-{{- tpl "if [ ! -f \"/galaxy/server/config/integrated_tool_panel.xml \" ]; then install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; fi; if [ ! -f \"/galaxy/server/config/sanitize_whitelist.txt \" ]; then install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt; fi" $}}
+if [ ! -f "/galaxy/server/config/integrated_tool_panel.xml" ]; then
+install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml;
+fi;
+if [ ! -f "/galaxy/server/config/sanitize_whitelist.txt" ]; then
+install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt;
+fi
+if [ ! -f "/galaxy/server/config/mutable/shed_data_manager_conf.xml" ]; then
+   install -o 101 -g 101 /galaxy/server/config/shed_data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
+fi
 {{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -93,9 +93,9 @@ Return galaxy database user password
 Creates the bash command for the init containers used to place files and change permissions in the galaxy pods
 */}}
 {{- define "galaxy.init-container-commands" -}}
-cp -an /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml;
-cp -an /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt;
-cp -an /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
-cp -an /galaxy/server/config/tool_data_table_conf.xml.sample /galaxy/server/config/mutable/shed_tool_data_table_conf.xml;
-cp -arn /galaxy/server/tool-data /galaxy/server/database/;
+cp -anL /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml;
+cp -anL /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt;
+cp -anL /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
+cp -anL /galaxy/server/config/tool_data_table_conf.xml.sample /galaxy/server/config/mutable/shed_tool_data_table_conf.xml;
+cp -arnL /galaxy/server/tool-data {{.Values.persistence.mountPath}}/;
 {{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -93,13 +93,8 @@ Return galaxy database user password
 Creates the bash command for the init containers used to place files and change permissions in the galaxy pods
 */}}
 {{- define "galaxy.init-container-commands" -}}
-if [ ! -f "/galaxy/server/config/integrated_tool_panel.xml" ]; then
-install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml;
-fi;
-if [ ! -f "/galaxy/server/config/sanitize_whitelist.txt" ]; then
-install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt;
-fi
-if [ ! -f "/galaxy/server/config/mutable/shed_data_manager_conf.xml" ]; then
-   install -o 101 -g 101 /galaxy/server/config/shed_data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
-fi
+cp -an /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml;
+cp -an /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt;
+cp -an /galaxy/server/config/shed_data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
+cp -an /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config/mutable/data_manager_conf.xml;
 {{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -95,6 +95,7 @@ Creates the bash command for the init containers used to place files and change 
 {{- define "galaxy.init-container-commands" -}}
 cp -an /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml;
 cp -an /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt;
-cp -an /galaxy/server/config/shed_data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
-cp -an /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config/mutable/data_manager_conf.xml;
+cp -an /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config/mutable/shed_data_manager_conf.xml;
+cp -an /galaxy/server/config/tool_data_table_conf.xml.sample /galaxy/server/config/mutable/shed_tool_data_table_conf.xml;
+cp -arn /galaxy/server/tool-data /galaxy/server/database/;
 {{- end -}}

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -196,14 +196,14 @@ configs:
       database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
-      tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
-      shed_tool_config_file: "{{.Values.persistence.mountPath}}/config/editable_shed_tool_conf.xml"
+      tool_config_file: "/galaxy/server/config/tool_conf.xml,/galaxy/server/config/mutable/shed_tool_conf.xml"
+      shed_tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml"
       tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/byhand/location/tool_data_table_conf.xml"
       tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
       builds_file_path: "{{.Values.cvmfs.data.mountPath}}/managed/location/builds.txt"
       datatypes_config_file: "{{ .Values.cvmfs.main.mountPath }}/config/datatypes_conf.xml"
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
-      workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
+      workflow_schedulers_config_file: "/galaxy/server/config/mutable/workflow_schedulers_conf.xml"
       build_sites_config_file: "/galaxy/server/config/build_sites.yml"
   container_resolvers_conf.xml: |
     <containers_resolvers>

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -196,15 +196,18 @@ configs:
       database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
-      tool_config_file: "/galaxy/server/config/tool_conf.xml,/galaxy/server/config/mutable/shed_tool_conf.xml"
+      tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml,/galaxy/server/config/tool_conf.xml"
       shed_tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml"
       tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/byhand/location/tool_data_table_conf.xml"
       tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
+      job_config_file: "/galaxy/server/config/job_conf.xml"
       builds_file_path: "{{.Values.cvmfs.data.mountPath}}/managed/location/builds.txt"
       datatypes_config_file: "{{ .Values.cvmfs.main.mountPath }}/config/datatypes_conf.xml"
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
       workflow_schedulers_config_file: "/galaxy/server/config/mutable/workflow_schedulers_conf.xml"
       build_sites_config_file: "/galaxy/server/config/build_sites.yml"
+      enable_data_manager_user_view: true
+      data_manager_config_file: "/galaxy/server/config/mutable/data_manager_conf.xml"
   container_resolvers_conf.xml: |
     <containers_resolvers>
       <explicit />

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -206,8 +206,9 @@ configs:
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
       workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
       build_sites_config_file: "/galaxy/server/config/build_sites.yml"
+      shed_data_manager_config_file: "/galaxy/server/config/mutable/shed_data_manager_conf.xml"
+      shed_tool_data_table_config: "/galaxy/server/config/mutable/shed_tool_data_table_conf.xml"
       enable_data_manager_user_view: true
-      data_manager_config_file: "/galaxy/server/config/mutable/data_manager_conf.xml"
   container_resolvers_conf.xml: |
     <containers_resolvers>
       <explicit />

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -196,7 +196,7 @@ configs:
       database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
-      tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml,/galaxy/server/config/tool_conf.xml"
+      tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
       shed_tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml"
       tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/byhand/location/tool_data_table_conf.xml"
       tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
@@ -204,7 +204,7 @@ configs:
       builds_file_path: "{{.Values.cvmfs.data.mountPath}}/managed/location/builds.txt"
       datatypes_config_file: "{{ .Values.cvmfs.main.mountPath }}/config/datatypes_conf.xml"
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
-      workflow_schedulers_config_file: "/galaxy/server/config/mutable/workflow_schedulers_conf.xml"
+      workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
       build_sites_config_file: "/galaxy/server/config/build_sites.yml"
       enable_data_manager_user_view: true
       data_manager_config_file: "/galaxy/server/config/mutable/data_manager_conf.xml"

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -187,10 +187,17 @@ configs:
     galaxy:
       database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
-      containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
-      job_config_file: "/galaxy/server/config/job_conf.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
-      integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
+      tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml,/galaxy/server/config/tool_conf.xml"
+      shed_tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml"
+      tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
+      job_config_file: "/galaxy/server/config/job_conf.xml"
+      containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
+      containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
+      workflow_schedulers_config_file: "/galaxy/server/config/mutable/workflow_schedulers_conf.xml"
+      build_sites_config_file: "/galaxy/server/config/build_sites.yml"
+      enable_data_manager_user_view: true
+      data_manager_config_file: "/galaxy/server/config/mutable/data_manager_conf.xml"
   container_resolvers_conf.xml: |
     <containers_resolvers>
       <explicit />

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -195,8 +195,9 @@ configs:
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
       workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
       build_sites_config_file: "/galaxy/server/config/build_sites.yml"
+      shed_data_manager_config_file: "/galaxy/server/config/mutable/shed_data_manager_conf.xml"
+      shed_tool_data_table_config: "/galaxy/server/config/mutable/shed_tool_data_table_conf.xml"
       enable_data_manager_user_view: true
-      data_manager_config_file: "/galaxy/server/config/mutable/data_manager_conf.xml"
   container_resolvers_conf.xml: |
     <containers_resolvers>
       <explicit />

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -193,8 +193,7 @@ configs:
       tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
       job_config_file: "/galaxy/server/config/job_conf.xml"
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
-      containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
-      workflow_schedulers_config_file: "/galaxy/server/config/mutable/workflow_schedulers_conf.xml"
+      workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
       build_sites_config_file: "/galaxy/server/config/build_sites.yml"
       enable_data_manager_user_view: true
       data_manager_config_file: "/galaxy/server/config/mutable/data_manager_conf.xml"


### PR DESCRIPTION
This fixes the following:
1. Some paths were using `/galaxy/server/config/mutable/` and some were using `{{.Values.persistence.mountPath}}/config/`, both of which are the same path. Simplified by always using `/galaxy/server/config/mutable/`
2. Use `cp -an` instead of `install` to simplify and avoid conditional check - but this needs to be tested
3. Bring values.yml and values-cvmfs into sync
4. Add `shed_data_manager_config_file` to mutable configs
5. `enable_data_manager_user_view: true` and also add `data_manager_conf.xml` to mutable configs (it's not clear whether the latter is mutable or not)