### PR TITLE
Added patched data manager containers till proper fix comes in

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -418,6 +418,16 @@ jobs:
     container_mapper_rules.yml: |
       mappings:
         - tool_ids:
+            - toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder/sam_fasta_index_builder/0.0.3
+          container:
+            docker_container_id_override: cloudve/sam-fasta-dm:latest
+            resource_set: small
+        - tool_ids:
+            - toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bwa_mem_index_builder/bwa_mem_index_builder_data_manager/0.0.4
+          container:
+            docker_container_id_override: cloudve/bwa-dm:latest
+            resource_set: small
+        - tool_ids:
             - sort1
             - Grouping1
           container:


### PR DESCRIPTION
The container for the bwa-mem index builder data manager and sam-fasta-index-builder data manager lack python, which causes them to fail. This PR includes some patched containers till the correct fix arrives: https://github.com/galaxyproject/tools-iuc/pull/2694/files