### PR TITLE
Add Summary Statistics container mapping

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -418,6 +418,11 @@ jobs:
     container_mapper_rules.yml: |
       mappings:
         - tool_ids:
+            - Summary_Statistics1
+          container:
+            docker_container_id_override: cloudve/gsummary:latest
+            resource_set: small
+        - tool_ids:
             - toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder/sam_fasta_index_builder/0.0.3
           container:
             docker_container_id_override: cloudve/sam-fasta-dm:latest

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -262,6 +262,11 @@ jobs:
     container_mapper_rules.yml: |
       mappings:
         - tool_ids:
+            - Summary_Statistics1
+          container:
+            docker_container_id_override: cloudve/gsummary:latest
+            resource_set: small
+        - tool_ids:
             - sort1
             - Grouping1
           container:


### PR DESCRIPTION
Given the Summary Statistics tool [indirectly requires R](https://github.com/galaxyproject/galaxy/blob/cbca8344631ca607f8db7ccf9388e5114d7c8ff6/tools/stats/gsummary.xml#L7), I think it should be pulled out the Galaxy codebase and into it's own tool tracked in the ToolShed. However, that's a sizable undertaking with a tool migration and all so probably not going to happen any time soon and hence this mapping is likely to stick around for a while. 