### PR TITLE
Add static-safe mapping to client/galaxy/images

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -223,6 +223,7 @@ configs:
       static-map: /static/style=/galaxy/server/static/style/blue
       static-map: /static=/galaxy/server/static
       static-map: /favicon.ico=/galaxy/server/static/favicon.ico
+      static-safe: /galaxy/server/client/galaxy/images
       mount: {{.Values.ingress.path}}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   galaxy.yml:
     galaxy:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -213,6 +213,7 @@ configs:
       static-map: /static/style=/galaxy/server/static/style/blue
       static-map: /static=/galaxy/server/static
       static-map: /favicon.ico=/galaxy/server/static/favicon.ico
+      static-safe: /galaxy/server/client/galaxy/images
       mount: {{.Values.ingress.path}}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   galaxy.yml:
     galaxy:


### PR DESCRIPTION
This fixes various fugue/etc icons not displaying correctly (https://github.com/galaxyproject/galaxy/issues/9080\#issuecomment-564590700)