### PR TITLE
DB Password

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -62,20 +62,15 @@ Return which PVC to use
 {{- end -}}
 
 {{/*
-Decide whether to create a new secret or use an existing secret.
-It creates a new secret if the value is the expected default, and assumes it's an
-existing secret in all other cases.
+Return extra env variables for all deployments
 */}}
-{{- define "galaxy.createGalaxyDbSecret" -}}
-{{- range $key, $entry := .Values.extraEnv -}}
-{{- if eq $entry.name "GALAXY_DB_USER_PASSWORD" -}}
-    {{- if eq $entry.valueFrom.secretKeyRef.name "{{ .Release.Name }}-galaxy-db-password" -}}
-        {{- true -}}
-    {{- else -}}
-    {{- end -}}
-{{- else -}}
-{{- end -}}
-{{- end -}}
+{{- define "galaxy.envVariables" -}}
+{{- defaultName := ({{ .Release.Name }}-galaxy-db-password | quote) }}
+- name: GALAXY_DB_USER_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default $defaultName .Values.postgresql.galaxyExistingSecret }}
+      key: {{ default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef }}
 {{- end -}}
 
 {{/*

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -82,6 +82,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+{{- include "galaxy.envVariables" . | nindent 12 -}}
 {{- if .Values.extraEnv }}
 {{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
 {{- end }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -69,6 +69,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+{{- include "galaxy.envVariables" . | nindent 12 -}}
 {{- if .Values.extraEnv }}
 {{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
 {{- end }}

--- a/galaxy/templates/secret-galaxydb.yaml
+++ b/galaxy/templates/secret-galaxydb.yaml
@@ -1,4 +1,4 @@
-{{- if (include "galaxy.createGalaxyDbSecret" .) }}
+{{- if .Values.postgresql.galaxyExistingSecret -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -15,7 +15,7 @@ metadata:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-  galaxy-db-password: {{ include "galaxy.galaxyDbPassword" . | b64enc | quote }}
   influxdb-user: {{ .Values.influxdb.username | b64enc | quote }}
   influxdb-password: {{ .Values.influxdb.password | b64enc | quote }}
+  {{ default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef }}: {{ include "galaxy.galaxyDbPassword" . | b64enc | quote }}
 {{- end }}

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -142,17 +142,14 @@ affinity: {}
 postgresql:
   enabled: true
   galaxyDatabaseUser: galaxydbuser
-  galaxyDatabasePassword: 42
+  # galaxyDatabasePassword: 42
+  # galaxyExistingSecret:
+  # galaxyExistingSecretKeyRef:
   nameOverride: galaxy-postgres
   initdbScriptsSecret: "{{ .Release.Name }}-galaxy-initdb"
   persistence:
     enabled: true
-  extraEnv:
-    - name: GALAXY_DB_USER_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: "{{ .Release.Name }}-galaxy-db-password"
-          key: galaxy-db-password
+  extraEnv: {}
 
 cvmfs:
   enabled: true
@@ -227,8 +224,6 @@ configs:
       mount: {{.Values.ingress.path}}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   galaxy.yml:
     galaxy:
-      database_connection: >
-        postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{include "galaxy-postgresql.fullname" .}}/galaxy
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
       tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -141,17 +141,14 @@ extraFileMappings:
 postgresql:
   enabled: true
   galaxyDatabaseUser: galaxydbuser
-  galaxyDatabasePassword: 42
+  # galaxyDatabasePassword: 42
+  # galaxyExistingSecret:
+  # galaxyExistingSecretKeyRef:
   nameOverride: galaxy-postgres
   initdbScriptsSecret: "{{ .Release.Name }}-galaxy-initdb"
   persistence:
     enabled: true
-  extraEnv:
-    - name: GALAXY_DB_USER_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: "{{ .Release.Name }}-galaxy-db-password"
-          key: galaxy-db-password
+  extraEnv: {}
 
 cvmfs:
   enabled: false
@@ -217,8 +214,6 @@ configs:
       mount: {{.Values.ingress.path}}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   galaxy.yml:
     galaxy:
-      database_connection: >
-        postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{include "galaxy-postgresql.fullname" .}}/galaxy
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
       tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml,/galaxy/server/config/tool_conf.xml"


### PR DESCRIPTION
Main changes:
- If db password is not specified, it will be auto-generated
- Regardless of whether auto-generated or specified, it will be stored in a secret
- Adding capabilities to specify an existing secret & key for the password via `galaxyExistingSecret` and `galaxyExistingSecretKeyRef`