### PR TITLE
WF2: Genome Annotation with Prokka

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -462,6 +462,10 @@ jobs:
             docker_container_id_override: cloudve/bwa-dm:latest
             resource_set: small
         - tool_ids:
+            - toolshed.g2.bx.psu.edu/repos/crs4/prokka/prokka/1.14.5
+          container:
+            docker_container_id_override: cloudve/prokka:1.14.5
+        - tool_ids:
             - toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.5+galaxy6
           container:
             docker_container_id_override: cloudve/jbrowse:1.16.5

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -462,6 +462,10 @@ jobs:
             docker_container_id_override: cloudve/bwa-dm:latest
             resource_set: small
         - tool_ids:
+            - toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.5+galaxy6
+          container:
+            docker_container_id_override: cloudve/jbrowse:1.16.5
+        - tool_ids:
             - sort1
             - Grouping1
           container:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -337,6 +337,10 @@ jobs:
             docker_container_id_override: cloudve/bwa-dm:latest
             resource_set: small
         - tool_ids:
+            - toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.5+galaxy6
+          container:
+            docker_container_id_override: cloudve/jbrowse:1.16.5
+        - tool_ids:
             - sort1
             - Grouping1
           container:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -337,6 +337,10 @@ jobs:
             docker_container_id_override: cloudve/bwa-dm:latest
             resource_set: small
         - tool_ids:
+            - toolshed.g2.bx.psu.edu/repos/crs4/prokka/prokka/1.14.5
+          container:
+            docker_container_id_override: cloudve/prokka:1.14.5
+        - tool_ids:
             - toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.5+galaxy6
           container:
             docker_container_id_override: cloudve/jbrowse:1.16.5


### PR DESCRIPTION
WF2 now works with these temporary containers.

Prokka is built based on biocontainer with the NFS patch applied: https://github.com/CloudVE/prokka-nfs-patch. The override can be removed once this PR is propagated and we drop the old version, or if it is backported: https://github.com/tseemann/prokka/pull/451

The JBrowse container is repackaged with `findutils` dependency (used by `jbrowse.py`). JBrowse override can be removed when this PR propagates: https://github.com/galaxyproject/tools-iuc/pull/2800