### PR TITLE
Make sure env vars are passed to all relevant pods

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -89,3 +89,15 @@ Extract the filename portion from a file path
 {{- define "galaxy.getFilenameFromPath" -}}
 {{- printf "%s" (. | splitList "/" | last) -}}
 {{- end -}}
+
+
+{{/*
+Define pod env vars
+*/}}
+{{- define "galaxy.podEnvVars" -}}
+{{- if .Values.extraEnv }}
+{{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
+{{- end }}
+            - name: GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
+              value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
+{{- end -}}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -54,6 +54,8 @@ spec:
         - name: {{ .Chart.Name }}-db-migrations
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: ['sh', '-c', '/galaxy/server/manage_db.sh upgrade']
+          env:
+          {{ include "galaxy.podEnvVars" . }}
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files
@@ -82,11 +84,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-{{- if .Values.extraEnv }}
-{{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
-{{- end }}
-            - name: GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
-              value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
+          {{ include "galaxy.podEnvVars" . }}
           command: [
             'sh', '-c',
             '{{- if .Values.extraInitCommands -}}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -69,11 +69,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-{{- if .Values.extraEnv }}
-{{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
-{{- end }}
-            - name: GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
-              value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
+          {{ include "galaxy.podEnvVars" . }}
           command: [
             'sh', '-c',
             '{{- if .Values.extraInitCommands -}}

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -64,15 +64,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-{{- if .Values.extraEnv }}
-{{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
-{{- end }}
-            - name: GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
-              value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
+          {{ include "galaxy.podEnvVars" . }}
           command: [
             'sh', '-c',
             '{{- if .Values.extraInitCommands -}}

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -233,6 +233,7 @@ configs:
       mount: {{.Values.ingress.path}}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   galaxy.yml:
     galaxy:
+      database_connection: postgresql://unused:because@overridden_by_envvar
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
       tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -222,6 +222,7 @@ configs:
       mount: {{.Values.ingress.path}}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   galaxy.yml:
     galaxy:
+      database_connection: postgresql://unused:because@overridden_by_envvar
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
       tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml,/galaxy/server/config/tool_conf.xml"


### PR DESCRIPTION
Make sure env vars are passed into all pods. Also add a dummy database_connection setting so that using the incorrect database connection will always result in an error, instead of silently defaulting to sqlite.