### PR TITLE
Don't allow underscores in extra file config map names

### DIFF
--- a/galaxy/templates/configmap-extra-files.yaml
+++ b/galaxy/templates/configmap-extra-files.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 metadata:
   # Extract the filename portion only
-  name: {{ include "galaxy.fullname" $ }}-{{ include "galaxy.getFilenameFromPath" $key | replace "." "-" }}
+  name: {{ include "galaxy.fullname" $ }}-{{ include "galaxy.getFilenameFromPath" $key | replace "." "-" | replace "_" "-" }}
   labels:
     app.kubernetes.io/name: {{ include "galaxy.name" $ }}
     helm.sh/chart: {{ include "galaxy.chart" $ }}


### PR DESCRIPTION
Config map names don't allow underscores