### PR TITLE
Revert "Quast override"

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -476,10 +476,6 @@ jobs:
           container:
             docker_container_id_override: cloudve/jbrowse:1.16.5
         - tool_ids:
-            - toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/5.0.2+galaxy0
-          container:
-            docker_container_id_override: cloudve/quast:5.0.2
-        - tool_ids:
             - sort1
             - Grouping1
           container:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -350,10 +350,6 @@ jobs:
           container:
             docker_container_id_override: cloudve/jbrowse:1.16.5
         - tool_ids:
-            - toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/5.0.2+galaxy0
-          container:
-            docker_container_id_override: cloudve/quast:5.0.2
-        - tool_ids:
             - sort1
             - Grouping1
           container:


### PR DESCRIPTION
This reverts commit 0dc97c1ef46fb9986d1f803b9d64733ecd214cbd.

https://github.com/BioContainers/multi-package-containers/pull/960 built `quay.io/biocontainers/quast:5.0.2--1` to which the tool now resolves without the override