### PR TITLE
Backdates API versions of Ingress and PriorityClass for 1.13 compatibility

### DIFF
--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/galaxy/templates/priorityclass-job.yaml
+++ b/galaxy/templates/priorityclass-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: {{ include "galaxy.fullname" . }}-job-priority


### PR DESCRIPTION
This PR re-enables backward compatibility with k8s 1.13 (.5 tested), addressing #106 