### PR TITLE
Refactor secret handling and add a new secret for id_secret

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Return galaxy database user password
 {{- if .Values.postgresql.galaxyDatabasePassword }}
     {{- .Values.postgresql.galaxyDatabasePassword -}}
 {{- else -}}
-    {{- randAlphaNum 10 -}}
+    {{- randAlphaNum 16 -}}
 {{- end -}}
 {{- end -}}
 
@@ -90,7 +90,6 @@ Extract the filename portion from a file path
 {{- printf "%s" (. | splitList "/" | last) -}}
 {{- end -}}
 
-
 {{/*
 Define pod env vars
 */}}
@@ -98,6 +97,11 @@ Define pod env vars
 {{- if .Values.extraEnv }}
 {{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
 {{- end }}
+            - name: GALAXY_DB_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: '{{default (printf "%s-galaxy-secrets" .Release.Name) .Values.postgresql.galaxyExistingSecret}}'
+                  key: '{{default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef}}'
             - name: GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
 {{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -104,4 +104,9 @@ Define pod env vars
                   key: '{{default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef}}'
             - name: GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
+            - name: GALAXY_CONFIG_OVERRIDE_ID_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-galaxy-secrets"
+                  key: "galaxy-config-id-secret"
 {{- end -}}

--- a/galaxy/templates/cron-metrics.yaml
+++ b/galaxy/templates/cron-metrics.yaml
@@ -29,7 +29,7 @@ spec:
               - name: PGPASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-galaxy-db-password"
+                    name: "{{ .Release.Name }}-galaxy-secrets"
                     key: galaxy-db-password
               - name: INFLUX_URL
                 value: "{{ .Values.influxdb.url }}"
@@ -38,12 +38,12 @@ spec:
               - name: INFLUX_USER
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-galaxy-db-password"
+                    name: "{{ .Release.Name }}-galaxy-secrets"
                     key: influxdb-user
               - name: INFLUX_PASS
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-galaxy-db-password"
+                    name: "{{ .Release.Name }}-galaxy-secrets"
                     key: influxdb-password
           restartPolicy: OnFailure
   concurrencyPolicy: Forbid

--- a/galaxy/templates/secret-galaxy.yaml
+++ b/galaxy/templates/secret-galaxy.yaml
@@ -14,6 +14,7 @@ metadata:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
+  galaxy-config-id-secret: {{  default (randAlphaNum 32) }}
 {{- if .Values.influxdb.enabled }}
   influxdb-user: {{ default "galaxy" .Values.influxdb.username | b64enc | quote }}
   influxdb-password: {{  default (randAlphaNum 16) .Values.influxdb.password | b64enc | quote }}

--- a/galaxy/templates/secret-galaxy.yaml
+++ b/galaxy/templates/secret-galaxy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ .Release.Name }}-galaxy-db-password
+  name: {{ .Release.Name }}-galaxy-secrets
   labels:
     app.kubernetes.io/name: {{ include "galaxy.name" . }}
     helm.sh/chart: {{ include "galaxy.chart" . }}
@@ -16,7 +16,7 @@ metadata:
 data:
 {{- if .Values.influxdb.enabled }}
   influxdb-user: {{ default "galaxy" .Values.influxdb.username | b64enc | quote }}
-  influxdb-password: {{  default (randAlphaNum 10) .Values.influxdb.password | b64enc | quote }}
+  influxdb-password: {{  default (randAlphaNum 16) .Values.influxdb.password | b64enc | quote }}
 {{- end -}}
 {{- if not .Values.postgresql.galaxyExistingSecret }}
   {{ default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef }}: {{ include "galaxy.galaxyDbPassword" . | b64enc | quote }}

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -96,12 +96,7 @@ extraFileMappings:
           </body>
       </html>
 
-extraEnv:
-- name: GALAXY_DB_USER_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: '{{default (printf "%s-galaxy-db-password" .Release.Name) .Values.postgresql.galaxyExistingSecret}}'
-      key: '{{default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef}}'
+extraEnv: []
 
 ingress:
   enabled: true
@@ -156,7 +151,7 @@ postgresql:
   - name: GALAXY_DB_USER_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: '{{default (printf "%s-galaxy-db-password" .Release.Name) .Values.galaxyExistingSecret}}'
+        name: '{{default (printf "%s-galaxy-secrets" .Release.Name) .Values.galaxyExistingSecret}}'
         key: '{{default "galaxy-db-password" .Values.galaxyExistingSecretKeyRef}}'
 
 cvmfs:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -38,12 +38,7 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
-extraEnv:
-- name: GALAXY_DB_USER_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: '{{default (printf "%s-galaxy-db-password" .Release.Name) .Values.postgresql.galaxyExistingSecret}}'
-      key: '{{default "galaxy-db-password" .Values.postgresql.galaxyExistingSecretKeyRef}}'
+extraEnv: []
 
 ingress:
   enabled: true
@@ -154,7 +149,7 @@ postgresql:
   - name: GALAXY_DB_USER_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: '{{default (printf "%s-galaxy-db-password" .Release.Name) .Values.galaxyExistingSecret}}'
+        name: '{{default (printf "%s-galaxy-secrets" .Release.Name) .Values.galaxyExistingSecret}}'
         key: '{{default "galaxy-db-password" .Values.galaxyExistingSecretKeyRef}}'
 
 cvmfs:


### PR DESCRIPTION
This PR removes the db password from extraEnv settings as it is not required to be configurable through extraEnv. Also, adds id_secret to galaxy config. Closes: https://github.com/galaxyproject/galaxy-helm/issues/85