### PR TITLE
Makes nodePort port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ current default values can be found in `values.yaml` file.
 | `image.repository`                      | The repository and name of the Docker image for Galaxy pointing to Docker Hub.                                                                |
 | `image.tag`                             | Galaxy image tag / version                                                                                                                    |
 | `image.pullPolicy`                      | Galaxy image pull policy                                                                                                                      |
-| `service.type`                          | Kubernetes Service type                                                                                                                       |
+| `service.type`                          | Kubernetes Service type, ClusterIP by default.                                                                                                                       |
 | `service.port`                          | Galaxy service port                                                                                                                           |
+| `service.nodePort`                      | If `service.type` set to `NodePort`, then this can be used to set the port at which Galaxy will be available on all nodes' IP addresses. `30700` by default.
+                                                        |
 | `webHandlers.replicaCount`              | The number of replicas for the Galaxy web handlers                                                                                            |
 | `jobHandlers.replicaCount`              | The number of replicas for the Galaxy job handlers                                                                                            |
 | `rbac.enabled`                          | Enable Galaxy job RBAC                                                                                                                        |

--- a/galaxy/templates/service.yaml
+++ b/galaxy/templates/service.yaml
@@ -11,6 +11,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.port }}
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     targetPort: galaxy-http
     protocol: TCP
     name: http

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -13,6 +13,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 8000
+  nodePort: 30700
 
 webHandlers:
   replicaCount: 1


### PR DESCRIPTION
This PR adds support for NodePort port to be configured through `service.ports[*].nodePort`. I have tested this to work in adequately changing the service when NodePort is set. It adds the default that we normally used on previous versions (which will make all my previous docs on galaxy kubernetes spread around the internet less outdated).