### PR TITLE
Do not create dynamic pvc if an existing one is set for Galaxy

### DIFF
--- a/galaxy/templates/pvc-galaxy.yaml
+++ b/galaxy/templates/pvc-galaxy.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.persistence.enabled -}}
+{{ if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
This PR fixes a bug where the dynamic pvc for Galaxy is still created when an existing PVC is set to be used.