### PR TITLE
Make dbinit optional and migration tips.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,21 @@ volume.
 
 ## Note about persistent deployments and restarts
 
-If you wish to make your deployment persistent or restartable (bring deployment down, keep the state in disk, then bring it up again later in time), you should create PVCs for Galaxy and Postgres and use the existingClaims variables to point to them as explained in the previous section. In addition, you MUST set the `postgresql.galaxyDatabasePassword` variable, as on a restart from the existing PVCs the Helm random password used for that slot won't be maintained, breaking database access.
+If you wish to make your deployment persistent or restartable (bring deployment down, keep the state in disk, then bring it up again later in time), you should create PVCs for Galaxy and Postgres and use the existingClaims variables to point to them as explained in the previous section. In addition, you MUST set the `postgresql.galaxyDatabasePassword` and `postgresql.postgresqlPassword` variables, as on a restart from the existing PVCs the Helm random password used for those slot won't be maintained, breaking database access.
+
+To start a new deployment from PVCs that belonged to a previous deployment on a different cluster, you might need to disable the database init part by setting `postgresql.initdbScriptsSecrets: null`. 
+
+### What if we didn't set db passwords in the first place
+
+You can allow trusted local connections and then use that to enter the postgresql server and change passwords. To allow trusted connections, set the pg_hba.conf file through:
+
+```
+postgresql:
+  pgHbaConfiguration: |
+    host     all             all             0.0.0.0/0               md5
+    host     all             all             ::1/128                 md5
+    local    all             all                                     trust
+```
 
 ## Production Settings
 

--- a/galaxy/files/conf.d/init1_dbobjects.sh
+++ b/galaxy/files/conf.d/init1_dbobjects.sh
@@ -3,8 +3,8 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 -v GXYPASSWORD="'$GALAXY_DB_USER_PASSWORD'" --username "$POSTGRESQL_USERNAME" --dbname "$POSTGRESQL_DATABASE" <<-EOSQL
-		CREATE DATABASE galaxy;
-		CREATE USER {{.Values.postgresql.galaxyDatabaseUser}};
+		CREATE IF NOT EXISTS DATABASE galaxy;
+		CREATE IF NOT EXISTS USER {{.Values.postgresql.galaxyDatabaseUser}};
 		ALTER ROLE {{.Values.postgresql.galaxyDatabaseUser}} WITH PASSWORD :GXYPASSWORD;
 		GRANT ALL PRIVILEGES ON DATABASE galaxy TO {{.Values.postgresql.galaxyDatabaseUser}};
 		ALTER DATABASE galaxy OWNER TO {{.Values.postgresql.galaxyDatabaseUser}};

--- a/galaxy/files/conf.d/init1_dbobjects.sh
+++ b/galaxy/files/conf.d/init1_dbobjects.sh
@@ -3,8 +3,8 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 -v GXYPASSWORD="'$GALAXY_DB_USER_PASSWORD'" --username "$POSTGRESQL_USERNAME" --dbname "$POSTGRESQL_DATABASE" <<-EOSQL
-		CREATE IF NOT EXISTS DATABASE galaxy;
-		CREATE IF NOT EXISTS USER {{.Values.postgresql.galaxyDatabaseUser}};
+		CREATE DATABASE galaxy;
+		CREATE USER {{.Values.postgresql.galaxyDatabaseUser}};
 		ALTER ROLE {{.Values.postgresql.galaxyDatabaseUser}} WITH PASSWORD :GXYPASSWORD;
 		GRANT ALL PRIVILEGES ON DATABASE galaxy TO {{.Values.postgresql.galaxyDatabaseUser}};
 		ALTER DATABASE galaxy OWNER TO {{.Values.postgresql.galaxyDatabaseUser}};

--- a/galaxy/templates/secret-initdb.yaml
+++ b/galaxy/templates/secret-initdb.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.postgresql.initdbScriptsSecret }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -13,3 +14,4 @@ stringData:
   {{ range $path, $bytes := .Files.Glob "files/conf.d/*" }}
     {{- base $path }}: {{ tpl ($root.Files.Get $path) $ | quote }}
   {{ end }}
+{{ end }}


### PR DESCRIPTION
This PR:

- Makes the dbinit part optional (for cases where you are re-using existing PVCs for postgresql that already have the database).
- Adds some pointers on the doc for migration cases.