### PR TITLE
Fixing job handlers number of deployments

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -175,4 +175,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+---
 {{- end }}


### PR DESCRIPTION
Without the `---` only the last API definition is deployed, resulting in ALWAYS 1 deployment, just changing the name. This will appropriately scale the deployments based on `jobHandlers.replicaCount`