### PR TITLE
Adding extra volumes and volume mounts for GVL shared-data

### DIFF
--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 20.01
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 name: galaxy
-version: 3.3.0
+version: 3.4.0

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -153,6 +153,9 @@ spec:
             - name: cvmfs-gxy-data
               mountPath: {{ $.Values.cvmfs.data.mountPath }}
             {{- end }}
+            {{- if $.Values.extraVolumeMounts }}
+            {{- $.Values.extraVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
       volumes:
@@ -196,6 +199,9 @@ spec:
         - name: cvmfs-gxy-data
           persistentVolumeClaim:
             claimName: {{ template "galaxy.fullname" $ }}-cvmfs-gxy-data-pvc
+        {{- end }}
+        {{- if $.Values.extraVolumes }}
+        {{- $.Values.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -125,6 +125,9 @@ spec:
             - name: cvmfs-gxy-data
               mountPath: {{ .Values.cvmfs.data.mountPath }}
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         # - name: nginx
@@ -171,6 +174,9 @@ spec:
         - name: cvmfs-gxy-data
           persistentVolumeClaim:
             claimName: {{ template "galaxy.fullname" . }}-cvmfs-gxy-data-pvc
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- .Values.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -107,6 +107,9 @@ spec:
             - name: cvmfs-gxy-data
               mountPath: {{ .Values.cvmfs.data.mountPath }}
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -147,6 +150,9 @@ spec:
         - name: cvmfs-gxy-data
           persistentVolumeClaim:
             claimName: {{ template "galaxy.fullname" . }}-cvmfs-gxy-data-pvc
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- .Values.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -49,6 +49,15 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
+# extraVolumes: |
+#   - name: shared-data
+#     persistentVolumeClaim:
+#       claimName: shared-data-pvc
+
+# extraVolumeMounts: |
+#   - name: shared-data
+#     mountPath: /opt/project/shared-data
+
 # extraInitContainers:
 #   - name: my-first-container
 #     applyToJob: true

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -50,6 +50,15 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
+# extraVolumes:
+#   - name: shared-data
+#     persistentVolumeClaim:
+#       claimName: shared-data-pvc
+
+# extraVolumeMounts:
+#   - name: shared-data
+#     mountPath: /opt/project/shared-data
+
 extraEnv: []
 
 ingress:


### PR DESCRIPTION
Generic functionality following the same model generally used by other charts.
Left to do for the GVL shared data:
-Add script to pre-populate a data library from the mounted volume