### PR TITLE
Adding auto-packaging Github action

### DIFF
--- a/.github/scripts/bump.sh
+++ b/.github/scripts/bump.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+GIT_BRANCH=${GIT_BRANCH:-master}
+
+git remote -v
+git pull
+if test $(git diff --name-status origin/"${GIT_BRANCH}" | grep -c "${CHART_NAME}/Chart.yml") = 0 ; then
+    echo "Extracting label information"
+    bump=$(python .github/scripts/extract_label.py)
+    if [ ! "$bump" = "nobump" ]; then
+        echo "Bumping version"
+        bump2version --current-version ${bump} ./${CHART_NAME}/Chart.yaml
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Automatic Version Bumping"
+
+        REPOSITORY=${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}
+        REMOTE="https://${GITHUB_ACTOR}:${GIT_TOKEN}@github.com/${REPOSITORY}.git"
+
+        echo "Push to branch $GIT_BRANCH";
+        [ -z "${GIT_TOKEN}" ] && {
+            echo 'Missing input "GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}".';
+            exit 1;
+        };
+
+        git push "${REMOTE}" HEAD:${GIT_BRANCH} -v -v
+    fi
+fi

--- a/.github/scripts/extract_label.py
+++ b/.github/scripts/extract_label.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import json
+import os
+import yaml
+
+chartName = os.getenv('CHART_NAME')
+
+with open(chartName + "/Chart.yaml", 'r') as chart:
+    d = yaml.safe_load(chart)
+
+bump = None
+labels = [l.get("name")
+          for l in json.loads(os.environ['GITHUB_CONTEXT'])['event']
+          ['pull_request'].get('labels', [])]
+
+if "patch" in labels:
+    bump = "patch"
+elif "feature" in labels:
+    bump = "minor"
+elif "version" in labels:
+    bump = "major"
+
+if bump:
+    print(" ".join([d['version'], bump]))
+else:
+    print("nobump")

--- a/.github/scripts/package.sh
+++ b/.github/scripts/package.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+[ -z "${GIT_TOKEN}" ] && {
+    echo 'Missing input "GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}".';
+    exit 1;
+};
+[ -z "${CHARTS_REPO}" ] && {
+    echo 'Missing input "CHARTS_REPO: cloudve/helm-charts".';
+    exit 1;
+};
+
+set -e
+
+BRANCH=${CHARTS_BRANCH:-master}
+CHARTS_DIR=$(basename $CHARTS_REPO)
+REMOTE="https://${GITHUB_ACTOR}:${GIT_TOKEN}@github.com/${CHARTS_REPO}.git"
+
+echo "Pushing to branch $BRANCH of repo $CHARTS_REPO";
+
+cd "${CHART_NAME}" && rm -rf charts && rm -f requirements.lock && helm dependency update && cd ..
+git clone "${REMOTE}" && cd "${CHARTS_DIR}" && git checkout $BRANCH && cd ..
+CHARTS_ABS_DIR=$(realpath $CHARTS_DIR)
+cd "${CHART_NAME}" && sh scripts/helm_package "${CHARTS_ABS_DIR}/charts" && cd ..
+cd "${CHARTS_DIR}" && helm repo index . --url "https://raw.githubusercontent.com/${CHARTS_REPO}/${BRANCH}/"
+git config --local user.email "action@github.com"
+git config --local user.name "GitHub Action"
+git add . && git commit -m "Automatic Packaging of ${CHART_NAME} chart" 
+git push "${REMOTE}" HEAD:${BRANCH};

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,36 @@
+name: Package
+# This workflow is triggered on pushes to the repository.
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  package:
+    name: Package and push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install bumpversion dependency
+        run: |
+          python -m pip install --upgrade pip
+          pip install bump2version pyyaml
+      - name: Bump version if necessary
+        run: sh -c 'sh ./.github/scripts/bump.sh'
+        shell: bash
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_BRANCH: ${{ github.event.pull_request.base.ref }}
+          CHART_NAME: galaxy
+      - name: Package and push to helm-charts
+        run: sh ./.github/scripts/package.sh
+        shell: bash
+        env:
+          CHARTS_REPO: cloudve/helm-charts
+          GIT_TOKEN: ${{ secrets.CHARTS_TOKEN }}
+          CHART_NAME: galaxy
+          CHARTS_BRANCH: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
CI to `rstudio-helm` was a proof of concept.
After adding, merged the PR changing image from rocker to bioconductor. This is the CI: https://github.com/CloudVE/rstudio-helm/pull/5/files. This is the merged PR: https://github.com/CloudVE/rstudio-helm/pull/2, which triggered: https://github.com/CloudVE/rstudio-helm/commit/7315373dcb7a19723d9094142fcea36ccd9669e4. After the version bump, the packaging was pushed to helm-charts: https://github.com/CloudVE/helm-charts/commit/06fec286c2a4fbceff05d01416692c35b0f4460c. The branches by default are always matching, i.e. if you merge a PR on the chart in `master` branch, it will repackage in `master` branch of `helm-charts`. If you merge a PR in `gvl-5.0`, it will repackage in `gvl-5.0` branch of `helm-charts`, etc...

This is the same CI with the only changes being the chart name and packaging using the `helm_package` script (copying the `values-cvmfs` as the default values file for the packaged chart)