### PR TITLE
Add extraVolumes to default job_conf

### DIFF
--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -49,12 +49,12 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
-# extraVolumes: |
+# extraVolumes:
 #   - name: shared-data
 #     persistentVolumeClaim:
 #       claimName: shared-data-pvc
 
-# extraVolumeMounts: |
+# extraVolumeMounts:
 #   - name: shared-data
 #     mountPath: /opt/project/shared-data
 
@@ -199,7 +199,30 @@ configs:
             <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4" />
             <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
               <param id="k8s_use_service_account">true</param>
-              <param id="k8s_persistent_volume_claims">{{ template "galaxy.pvcname" . }}:{{.Values.persistence.mountPath}},{{ template "galaxy.fullname" . }}-cvmfs-gxy-data-pvc:{{ .Values.cvmfs.data.mountPath }},{{ template "galaxy.fullname" . }}-cvmfs-gxy-main-pvc:{{ .Values.cvmfs.main.mountPath }}</param>
+              <param id="k8s_persistent_volume_claims">
+              {{- template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}},
+              {{- template "galaxy.fullname" . }}-cvmfs-gxy-data-pvc:{{ .Values.cvmfs.data.mountPath }},
+              {{- template "galaxy.fullname" . }}-cvmfs-gxy-main-pvc:{{ .Values.cvmfs.main.mountPath -}}
+              {{- if .Values.extraVolumes }}
+                {{- range $num, $entry := .Values.extraVolumes }}
+                  {{- if $entry.name }}
+                    {{- if $entry.persistentVolumeClaim}}
+                      {{- if $entry.persistentVolumeClaim.claimName }}
+                        {{- range $num, $mount := $.Values.extraVolumeMounts }}
+                          {{- if $mount.name }}
+                            {{- if (eq $entry.name $mount.name) }}
+                              {{- if $mount.mountPath -}}
+                                ,{{- $entry.persistentVolumeClaim.claimName -}}:{{- $mount.mountPath -}}
+                              {{- end }}
+                            {{- end }}
+                          {{- end }}
+                        {{- end }}
+                      {{- end }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+              {{- end -}}
+              </param>
               <param id="k8s_namespace">{{ .Release.Namespace }}</param>
               <!-- Must be DNS friendly and less than 20 characters -->
               <param id="k8s_galaxy_instance_id">{{ .Release.Name }}</param>

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -188,7 +188,28 @@ configs:
             <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4" />
             <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
               <param id="k8s_use_service_account">true</param>
-              <param id="k8s_persistent_volume_claims">{{ template "galaxy.pvcname" . }}:{{.Values.persistence.mountPath}}</param>
+              <param id="k8s_persistent_volume_claims">
+              {{- template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}}
+              {{- if .Values.extraVolumes }}
+                {{- range $num, $entry := .Values.extraVolumes }}
+                  {{- if $entry.name }}
+                    {{- if $entry.persistentVolumeClaim}}
+                      {{- if $entry.persistentVolumeClaim.claimName }}
+                        {{- range $num, $mount := $.Values.extraVolumeMounts }}
+                          {{- if $mount.name }}
+                            {{- if (eq $entry.name $mount.name) }}
+                              {{- if $mount.mountPath -}}
+                                ,{{- $entry.persistentVolumeClaim.claimName -}}:{{- $mount.mountPath -}}
+                              {{- end }}
+                            {{- end }}
+                          {{- end }}
+                        {{- end }}
+                      {{- end }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+              {{- end -}}
+              </param>
               <param id="k8s_namespace">{{ .Release.Namespace }}</param>
               <!-- Must be DNS friendly and less than 20 characters -->
               <param id="k8s_galaxy_instance_id">{{ .Release.Name }}</param>


### PR DESCRIPTION
PVCs (only, i.e. not configmaps/secrets) mounted through `extraVolumes` and `extraVolumeMounts` will also be added to the default `job_conf.xml` to be mounted in the job containers. While in the actual rendered values the spaces are all removed, I also changed the previous entries in `values-cvmfs.yaml` to be one per line for easier reading, and then added the logic making the indentation explicit for easier reading. Essentially if there is an `extraVolume` entry with a valid `name` and a valid `persistentVolumeClaim.claimName`, and a corresponding `extraVolumeMount` with the same name and a valid `mountPath`, these values will be appended to the `job_conf.xml` as `,{{$volume.persistentVolumeClaim.claimName:$volumeMount.mountPath}}`. Easiest test is uncommenting the `extraVolumes/volumeMounts` and doing a `helm template`. You can see the rendered `job_conf` will properly list all the volumes