### PR TITLE
[WIP] Add customVolume option to persistence (for special built-in volumes eg: CephFS)

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -186,7 +186,9 @@ spec:
           configMap:
             name: {{ template "galaxy.fullname" $ }}-job-rules
         - name: galaxy-data
-          {{- if $.Values.persistence.enabled }}
+          {{- if $.Values.persistence.customVolume -}}
+          {{- $.Values.persistence.customVolume | toYaml | nindent 10}}
+          {{- else if $.Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ template "galaxy.pvcname" $ }}
           {{- else }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -161,7 +161,9 @@ spec:
           configMap:
             name: {{ template "galaxy.fullname" . }}-job-rules
         - name: galaxy-data
-          {{- if .Values.persistence.enabled }}
+          {{- if $.Values.persistence.customVolume -}}
+          {{- $.Values.persistence.customVolume | toYaml | nindent 10}}
+          {{- else if $.Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ template "galaxy.pvcname" . }}
           {{- else }}

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -137,7 +137,9 @@ spec:
           configMap:
             name: {{ template "galaxy.fullname" . }}-job-rules
         - name: galaxy-data
-          {{- if .Values.persistence.enabled }}
+          {{- if $.Values.persistence.customVolume -}}
+          {{- $.Values.persistence.customVolume | toYaml | nindent 10}}
+          {{- else if $.Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ template "galaxy.pvcname" . }}
           {{- else }}

--- a/galaxy/templates/pvc-galaxy.yaml
+++ b/galaxy/templates/pvc-galaxy.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{ if and .Values.persistence.enabled  (and (not .Values.persistence.customVolume) (not .Values.persistence.existingClaim)) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -48,6 +48,16 @@ persistence:
   accessMode: ReadWriteMany
   size: 10Gi
   mountPath: /galaxy/server/database
+  customVolume: {}
+    # cephfs:
+    #   monitors:
+    #   - 192.102.25.11:6789
+    #   - 192.102.25.19:6789
+    #   - 192.102.25.28:6789
+    #   path: /volumes/my-special-volume/galaxy
+    #   secretRef:
+    #     name: ceph-secret
+    #   user: myuser
 
 # extraVolumes:
 #   - name: shared-data

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -49,6 +49,16 @@ persistence:
   accessMode: ReadWriteMany
   size: 10Gi
   mountPath: /galaxy/server/database
+  customVolume: {}
+    # cephfs:
+    #   monitors:
+    #   - 192.102.25.11:6789
+    #   - 192.102.25.19:6789
+    #   - 192.102.25.28:6789
+    #   path: /volumes/my-special-volume/galaxy
+    #   secretRef:
+    #     name: ceph-secret
+    #   user: myuser
 
 # extraVolumes:
 #   - name: shared-data


### PR DESCRIPTION
This should make what we did manually with @chrisbarnettster replicable with any CephFS and any other type of custom volumes.
Note: this requires `ceph-common` (and I think also `ceph-fuse`) to be installed on all the nodes. More generally, the `mount -t [storageType]` should work on all the nodes, so for things other than Ceph the corresponding libraries should be installed

This needs a k8s runner change as well