### PR TITLE
Web probes get /api/version

### DIFF
--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -83,13 +83,13 @@ spec:
           args: []
           readinessProbe:
             httpGet:
-              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
+              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}/api/version
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 15
           livenessProbe:
             httpGet:
-              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
+              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}/api/version
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 60


### PR DESCRIPTION
Getting root path for Galaxy would sometimes cause errors (see https://gist.githubusercontent.com/almahmoud/c1e32962b4a931d96c94ffb941ea15eb/raw/aa85624eb4abc3bbcb506dbe7b606fe70c666710/log-web-alexo-anvil-sep-22.log). Since the probes determine whether the handler can receive requests, the intermittent error would cause the handler to be temporarily marked unhealthy, making the GKE Load Balancer stop requests from hitting the handler, making Galaxy intermittently seem down for a little bit of time.
@dannon suggested it might be due to the size of what needs to be rendered for the Galaxy homepage, and to check the `/api/version` endpoint instead. This seems to have fixed the intermittent issues on GKE.