### PR TITLE
Adding probes to workflow handlers + adding startup probes + parametrizing web probes

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -99,16 +99,6 @@ spec:
              {{- end -}}
              python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name job_handler_{{ $handler_num }} --attach-to-pool job-handlers']
           args: []
-          startupProbe:
-            exec:
-              command: [
-                'sh', '-c',
-                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
-              ]
-            initialDelaySeconds: {{ $.Values.jobHandlers.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ $.Values.jobHandlers.startupProbe.periodSeconds }}
-            failureThreshold: {{ $.Values.jobHandlers.startupProbe.failureThreshold }}
-            timeoutSeconds: {{ $.Values.jobHandlers.startupProbe.failureThreshold }}
           readinessProbe:
             exec:
               command: [

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -99,6 +99,16 @@ spec:
              {{- end -}}
              python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name job_handler_{{ $handler_num }} --attach-to-pool job-handlers']
           args: []
+          startupProbe:
+            exec:
+              command: [
+                'sh', '-c',
+                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
+              ]
+            initialDelaySeconds: {{ $.Values.jobHandlers.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ $.Values.jobHandlers.startupProbe.periodSeconds }}
+            failureThreshold: {{ $.Values.jobHandlers.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ $.Values.jobHandlers.startupProbe.failureThreshold }}
           readinessProbe:
             exec:
               command: [

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -81,14 +81,6 @@ spec:
              {{- end -}}
              /galaxy/server/.venv/bin/uwsgi --yaml /galaxy/server/config/uwsgi.yml --set galaxy_config_file=/galaxy/server/config/galaxy.yml']
           args: []
-          startupProbe:
-            httpGet:
-              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/version
-              port: 8080
-            initialDelaySeconds: {{ .Values.webHandlers.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.webHandlers.startupProbe.periodSeconds }}
-            failureThreshold: {{ .Values.webHandlers.startupProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.webHandlers.startupProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/version

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -83,7 +83,7 @@ spec:
           args: []
           startupProbe:
             httpGet:
-              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
+              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/version
               port: 8080
             initialDelaySeconds: {{ .Values.webHandlers.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webHandlers.startupProbe.periodSeconds }}
@@ -91,7 +91,7 @@ spec:
             timeoutSeconds: {{ .Values.webHandlers.startupProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
+              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/version
               port: 8080
             initialDelaySeconds: {{ .Values.webHandlers.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webHandlers.livenessProbe.periodSeconds }}
@@ -99,7 +99,7 @@ spec:
             timeoutSeconds: {{ .Values.webHandlers.livenessProbe.failureThreshold }}
           livenessProbe:
             httpGet:
-              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
+              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/version
               port: 8080
             initialDelaySeconds: {{ .Values.webHandlers.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webHandlers.livenessProbe.periodSeconds }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -85,15 +85,18 @@ spec:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
               port: 8080
-            initialDelaySeconds: 30
-            periodSeconds: 15
+            initialDelaySeconds: {{ .Values.webHandlerss.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webHandlerss.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
           livenessProbe:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
               port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 60
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.webHandlerss.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webHandlerss.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
           volumeMounts:
             {{- range $key, $entry := .Values.extraFileMappings -}}
             {{- if $entry.applyToWeb }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -81,22 +81,30 @@ spec:
              {{- end -}}
              /galaxy/server/.venv/bin/uwsgi --yaml /galaxy/server/config/uwsgi.yml --set galaxy_config_file=/galaxy/server/config/galaxy.yml']
           args: []
+          startupProbe:
+            httpGet:
+              path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.webHandlers.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webHandlers.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.webHandlers.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.webHandlers.startupProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
               port: 8080
-            initialDelaySeconds: {{ .Values.webHandlerss.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.webHandlerss.livenessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.webHandlers.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webHandlers.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.webHandlers.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.webHandlers.livenessProbe.failureThreshold }}
           livenessProbe:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
               port: 8080
-            initialDelaySeconds: {{ .Values.webHandlerss.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.webHandlerss.livenessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.webHandlerss.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.webHandlers.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webHandlers.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.webHandlers.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.webHandlers.livenessProbe.failureThreshold }}
           volumeMounts:
             {{- range $key, $entry := .Values.extraFileMappings -}}
             {{- if $entry.applyToWeb }}

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -160,6 +160,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+        - name: extra-files-probe-script
+          configMap:
+            name: {{ template "galaxy.fullname" $ }}-probedb-py
         - name: galaxy-conf-files
           {{- if .Values.useSecretConfigs }}
           secret:

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -80,26 +80,6 @@ spec:
              {{- end -}}
              python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name workflow_scheduler0']
           args: []
-          startupProbe:
-            exec:
-              command: [
-                'sh', '-c',
-                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
-              ]
-            initialDelaySeconds: {{ .Values.workflowHandlers.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.workflowHandlers.startupProbe.periodSeconds }}
-            failureThreshold: {{ .Values.workflowHandlers.startupProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.workflowHandlers.startupProbe.failureThreshold }}
-          livenessProbe:
-            exec:
-              command: [
-                'sh', '-c',
-                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
-              ]
-            initialDelaySeconds: {{ .Values.workflowHandlers.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.workflowHandlers.livenessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.workflowHandlers.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.workflowHandlers.livenessProbe.failureThreshold }}
           readinessProbe:
             exec:
               command: [

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "galaxy.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.jobHandlers.annotations }}
+{{- with .Values.workflowHandlers.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -26,7 +26,7 @@ spec:
         checksum/galaxy_conf: {{ include (print $.Template.BasePath "/configs-galaxy.yaml") . | sha256sum }}
         checksum/galaxy_rules: {{ include (print $.Template.BasePath "/configmap-galaxy-rules.yaml") . | sha256sum }}
         checksum/galaxy_extras: {{ include (print $.Template.BasePath "/configmap-extra-files.yaml") . | sha256sum }}
-        {{- with .Values.jobHandlers.podAnnotations -}}
+        {{- with .Values.workflowHandlers.podAnnotations -}}
         {{ toYaml . | nindent 8 }}
         {{ end }}
     spec:
@@ -68,6 +68,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{ include "galaxy.podEnvVars" . }}
           command: [
             'sh', '-c',
@@ -76,7 +80,30 @@ spec:
              {{- end -}}
              python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name workflow_scheduler0']
           args: []
+          readinessProbe:
+            exec:
+              command: [
+                'sh', '-c',
+                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
+              ]
+            initialDelaySeconds: {{ .Values.workflowHandlers.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workflowHandlers.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.workflowHandlers.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.workflowHandlers.readinessProbe.failureThreshold }}
+          livenessProbe:
+            exec:
+              command: [
+                'sh', '-c',
+                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
+              ]
+            initialDelaySeconds: {{ .Values.workflowHandlers.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workflowHandlers.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.workflowHandlers.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.workflowHandlers.livenessProbe.failureThreshold }}
           volumeMounts:
+            - name: extra-files-probe-script
+              mountPath: /tmp/probedb.py
+              subPath: probedb.py
             {{- range $key, $entry := .Values.extraFileMappings -}}
             {{- if $entry.applyToJob }}
             - name: extra-files-{{ include "galaxy.getFilenameFromPath" $key | replace "." "-" }}

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.workflowHandlers.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "galaxy.fullname" . }}
@@ -80,6 +80,26 @@ spec:
              {{- end -}}
              python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name workflow_scheduler0']
           args: []
+          startupProbe:
+            exec:
+              command: [
+                'sh', '-c',
+                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
+              ]
+            initialDelaySeconds: {{ .Values.workflowHandlers.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workflowHandlers.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.workflowHandlers.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.workflowHandlers.startupProbe.failureThreshold }}
+          livenessProbe:
+            exec:
+              command: [
+                'sh', '-c',
+                'python /tmp/probedb.py -e $GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION -o $POD_NAME'
+              ]
+            initialDelaySeconds: {{ .Values.workflowHandlers.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workflowHandlers.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.workflowHandlers.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.workflowHandlers.livenessProbe.failureThreshold }}
           readinessProbe:
             exec:
               command: [

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -18,11 +18,6 @@ workflowHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
-  startupProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 720
-    timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
     failureThreshold: 12
@@ -36,11 +31,6 @@ webHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
-  startupProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 720
-    timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
     failureThreshold: 12
@@ -54,11 +44,6 @@ jobHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
-  startupProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 720
-    timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
     failureThreshold: 12

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -14,32 +14,59 @@ service:
   type: ClusterIP
   port: 8000
 
-webHandlers:
-  replicaCount: 1
-  annotations: {}
-  podAnnotations: {}
-
 workflowHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
+  startupProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 720
+    timeoutSeconds: 5
+  readinessProbe:
+    periodSeconds: 10
+    failureThreshold: 12
+    timeoutSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 5
+
+webHandlers:
+  replicaCount: 1
+  annotations: {}
+  podAnnotations: {}
+  startupProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 720
+    timeoutSeconds: 5
+  readinessProbe:
+    periodSeconds: 10
+    failureThreshold: 12
+    timeoutSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 5
 
 jobHandlers:
   replicaCount: 1
-  # Annotations are used for both job and workflow deployments
   annotations: {}
   podAnnotations: {}
-  # Probe variables
+  startupProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 720
+    timeoutSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 12
+    timeoutSeconds: 5
   livenessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 5
 
 rbac:
   enabled: true

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -19,6 +19,11 @@ webHandlers:
   annotations: {}
   podAnnotations: {}
 
+workflowHandlers:
+  replicaCount: 1
+  annotations: {}
+  podAnnotations: {}
+
 jobHandlers:
   replicaCount: 1
   # Annotations are used for both job and workflow deployments

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -19,6 +19,11 @@ workflowHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 60
@@ -34,6 +39,11 @@ webHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 60
@@ -51,6 +61,11 @@ jobHandlers:
   annotations: {}
   podAnnotations: {}
   # Probe variables
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 60

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -20,40 +20,36 @@ workflowHandlers:
   annotations: {}
   podAnnotations: {}
   startupProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 720
+    timeoutSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 6
+    timeoutSeconds: 5
   livenessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 12
+    timeoutSeconds: 5
 
 webHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
   startupProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 720
+    timeoutSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 6
+    timeoutSeconds: 5
   livenessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 12
+    timeoutSeconds: 5
 
 jobHandlers:
   replicaCount: 1
@@ -62,20 +58,18 @@ jobHandlers:
   podAnnotations: {}
   # Probe variables
   startupProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 720
+    timeoutSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 6
+    timeoutSeconds: 5
   livenessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 10
-    timeoutSeconds: 3
+    periodSeconds: 10
+    failureThreshold: 12
+    timeoutSeconds: 5
 
 rbac:
   enabled: true

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -15,10 +15,35 @@ service:
   port: 8000
   nodePort: 30700
 
+workflowHandlers:
+  replicaCount: 1
+  annotations: {}
+  podAnnotations: {}
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
+
 webHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 3
 
 jobHandlers:
   replicaCount: 1

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -19,11 +19,6 @@ workflowHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
-  startupProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 720
-    timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
     failureThreshold: 12
@@ -37,11 +32,6 @@ webHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
-  startupProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 720
-    timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
     failureThreshold: 12
@@ -55,11 +45,6 @@ jobHandlers:
   replicaCount: 1
   annotations: {}
   podAnnotations: {}
-  startupProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 720
-    timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
     failureThreshold: 12

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -26,11 +26,11 @@ workflowHandlers:
     timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
-    failureThreshold: 6
+    failureThreshold: 12
     timeoutSeconds: 5
   livenessProbe:
     periodSeconds: 10
-    failureThreshold: 12
+    failureThreshold: 30
     timeoutSeconds: 5
 
 webHandlers:
@@ -44,19 +44,17 @@ webHandlers:
     timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
-    failureThreshold: 6
+    failureThreshold: 12
     timeoutSeconds: 5
   livenessProbe:
     periodSeconds: 10
-    failureThreshold: 12
+    failureThreshold: 30
     timeoutSeconds: 5
 
 jobHandlers:
   replicaCount: 1
-  # Annotations are used for both job and workflow deployments
   annotations: {}
   podAnnotations: {}
-  # Probe variables
   startupProbe:
     initialDelaySeconds: 30
     periodSeconds: 5
@@ -64,11 +62,11 @@ jobHandlers:
     timeoutSeconds: 5
   readinessProbe:
     periodSeconds: 10
-    failureThreshold: 6
+    failureThreshold: 12
     timeoutSeconds: 5
   livenessProbe:
     periodSeconds: 10
-    failureThreshold: 12
+    failureThreshold: 30
     timeoutSeconds: 5
 
 rbac:


### PR DESCRIPTION
-Workflow handlers using the same script designed by Luke for job handlers, probing the heartbeat in the DB.
-Startup probes added so we can choose values for the other probes without worrying about startup.
-Parametrized web handler probes to more easily change values per deployment (eg: if running on a slower cloud)
-Rolled in https://github.com/galaxyproject/galaxy-helm/pull/162 into this as well