### PR TITLE
Add Kubernetes Service Account to deployments and Role

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 101
-      serviceAccountName: {{ .Values.rbac.serviceAccount }}
+      serviceAccountName: {{ $.Values.rbac.serviceAccount }}
       initContainers:
         - name: {{ $.Chart.Name }}-init-postgres
           image: alpine:3.7

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -33,6 +33,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 101
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}
       initContainers:
         - name: {{ $.Chart.Name }}-init-postgres
           image: alpine:3.7

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -33,6 +33,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 101
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}
       initContainers:
         - name: {{ .Chart.Name }}-init-postgres
           image: alpine:3.7

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 101
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}
       initContainers:
         - name: {{ .Chart.Name }}-init-postgres
           image: alpine:3.7

--- a/galaxy/templates/rbac-job.yaml
+++ b/galaxy/templates/rbac-job.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ .Values.rbac.serviceAccount }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -38,6 +38,7 @@ jobHandlers:
 
 rbac:
   enabled: true
+  serviceAccount: default
 
 persistence:
   enabled: true

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -39,6 +39,7 @@ jobHandlers:
 
 rbac:
   enabled: true
+  serviceAccount: default
 
 persistence:
   enabled: true


### PR DESCRIPTION
Kept the default as "default".

Addresses https://github.com/galaxyproject/galaxy-helm/issues/150

Now fully tested with workload identity from Leo and Luke's AnvilFS.