### PR TITLE
Fixed incorrect indentation in config maps

### DIFF
--- a/galaxy/templates/configs-galaxy.yaml
+++ b/galaxy/templates/configs-galaxy.yaml
@@ -16,10 +16,10 @@ data:
 {{- end }}
   {{- range $key, $entry := .Values.configs -}}
   {{- if $entry -}}
-  {{- $key | nindent 4 }}: |
+  {{- $key | nindent 2 }}: |
   {{- $original := (toYaml $entry) -}}
   {{- $nomultiline := (regexReplaceAll "^^\\s*\\|\\n*" $original "") -}}
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
-  {{- tpl (tpl $nowhitespace $) $ | trim | nindent 8 -}}
+  {{- tpl (tpl $nowhitespace $) $ | nindent 4 -}}
   {{- end -}}
   {{- end -}}


### PR DESCRIPTION
The `trim` causes leading space to be removed from the config entry, which results in incorrectly indented values.