### PR TITLE
205 ingress template

### DIFF
--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,10 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-nginx
-              servicePort: {{ $servicePort }}
-  {{- end }}
+              service:
+                name: {{ $fullName }}-nginx
+                port:
+                  number: {{ $servicePort }}  {{- end }}
 {{- end }}

--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -37,5 +37,6 @@ spec:
               service:
                 name: {{ $fullName }}-nginx
                 port:
-                  number: {{ $servicePort }}  {{- end }}
+                  number: {{ $servicePort }}  
+  {{- end }}
 {{- end }}

--- a/galaxy/templates/priorityclass-job.yaml
+++ b/galaxy/templates/priorityclass-job.yaml
@@ -1,5 +1,5 @@
 {{ if and .Values.jobHandlers.priorityClass.enabled (not .Values.jobHandlers.priorityClass.existingClass) }}
-apiVersion: scheduling.k8s.io/v1beta1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "galaxy.pod-priority-class" . }}


### PR DESCRIPTION
Update apiVersion for priorityclass-job.yaml and ingress.yaml

Both files used beta versions (v1beta1) in the `apiVersion` field; these have been updated to `scheduling.k8s.io/v1` and `networking.k8s.io/v1` respectively.  This PR also includes minor syntax updates for the `http.paths.path` block, in particular the changes to the service port name and number.

Fixes #205 