### PR TITLE
Fix cvmfs PVC dependency and nginx conf

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -55,7 +55,7 @@ data:
                 include uwsgi_params;
             }
 
-            location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}_x_accel_redirect {
+            location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}_x_accel_redirect/ {
                 internal;
                 alias /;
                 add_header X-Frame-Options SAMEORIGIN;

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -213,9 +213,9 @@ configs:
             <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
               <param id="k8s_use_service_account">true</param>
               <param id="k8s_persistent_volume_claims">
-              {{- template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}},
+              {{- template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}}
               {{- if .Values.cvmfs.enabled -}}
-              {{- template "galaxy.fullname" . -}}-cvmfs-gxy-data-pvc:{{.Values.cvmfs.data.mountPath}},
+              ,{{- template "galaxy.fullname" . -}}-cvmfs-gxy-data-pvc:{{.Values.cvmfs.data.mountPath}},
               {{- template "galaxy.fullname" . -}}-cvmfs-gxy-main-pvc:{{.Values.cvmfs.data.mountPath}}
               {{- end -}}
               {{- if .Values.extraVolumes -}}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -214,8 +214,10 @@ configs:
               <param id="k8s_use_service_account">true</param>
               <param id="k8s_persistent_volume_claims">
               {{- template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}},
-              {{- template "galaxy.fullname" . }}-cvmfs-gxy-data-pvc:{{ .Values.cvmfs.data.mountPath }},
-              {{- template "galaxy.fullname" . }}-cvmfs-gxy-main-pvc:{{ .Values.cvmfs.main.mountPath -}}
+              {{- if .Values.cvmfs.enabled -}}
+              {{- template "galaxy.fullname" . -}}-cvmfs-gxy-data-pvc:{{.Values.cvmfs.data.mountPath}},
+              {{- template "galaxy.fullname" . -}}-cvmfs-gxy-main-pvc:{{.Values.cvmfs.data.mountPath}}
+              {{- end -}}
               {{- if .Values.extraVolumes -}}
               {{- template "galaxy.extra_pvc_mounts" . -}}
               {{- end -}}


### PR DESCRIPTION
Regarding #219 , I added check into `values.yaml` whether cvmfs is enabled. If true, only then include cvmfs PVCs into `job_conf.xml`

Secondly, I added trailing slash into `configmap-nginx`. Without it, the redirect didn't work and also  [official documentation](https://docs.galaxyproject.org/en/master/admin/nginx.html#sending-files-with-nginx) states that in the nginx, the trailing slash should be present.