### PR TITLE
Bad typo in job conf

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -226,7 +226,7 @@ configs:
               {{- template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}}
               {{- if .Values.cvmfs.enabled -}}
               ,{{- template "galaxy.fullname" . -}}-cvmfs-gxy-data-pvc:{{.Values.cvmfs.data.mountPath}},
-              {{- template "galaxy.fullname" . -}}-cvmfs-gxy-main-pvc:{{.Values.cvmfs.data.mountPath}}
+              {{- template "galaxy.fullname" . -}}-cvmfs-gxy-main-pvc:{{.Values.cvmfs.main.mountPath}}
               {{- end -}}
               {{- if .Values.extraVolumes -}}
               {{- template "galaxy.extra_pvc_mounts" . -}}


### PR DESCRIPTION
Missed small typo from https://github.com/galaxyproject/galaxy-helm/pull/222/files which was causing jobs to not be able to run (not unique mountPaths)