### PR TITLE
Pull policy on initcontainers

### DIFF
--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -50,6 +50,7 @@ spec:
               mountPath: {{ $.Values.persistence.mountPath }}
         - name: {{ $.Chart.Name }}-init-mounts
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command: ['sh', '-c', {{ include "galaxy.init-container-commands" $ | squote }}]
           volumeMounts:
             {{- range $key,$entry := $.Values.configs }}
@@ -66,6 +67,7 @@ spec:
               mountPath: {{ $.Values.persistence.mountPath }}
         - name: {{ $.Chart.Name }}-db-migrations
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command: ['sh', '-c', '/galaxy/server/manage_db.sh upgrade']
           env:
           {{ include "galaxy.podEnvVars" $ }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -49,6 +49,7 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
         - name: {{ .Chart.Name }}-init-mounts
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', {{ include "galaxy.init-container-commands" . | squote }}]
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -49,6 +49,7 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
         - name: {{ .Chart.Name }}-init-mounts
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', {{ include "galaxy.init-container-commands" . | squote }}]
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}


### PR DESCRIPTION
Came up with @luke-c-sargent that the handler images were being pulled despite the pullPolicy because of an init container defaulting to `Always`