### PR TITLE
Trimming newline on pod priority class

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -237,10 +237,10 @@ configs:
         k8s_supplemental_group_id: "101"
         k8s_pull_policy: IfNotPresent
         k8s_cleanup_job: onsuccess
-        k8s_pod_priority_class: >
-          {{ if .Values.jobHandlers.priorityClass.enabled }}
-          {{ include "galaxy.fullname" . }}-job-priority
-          {{ end }}
+        k8s_pod_priority_class: >-
+          {{ if .Values.jobHandlers.priorityClass.enabled -}}
+          {{- include "galaxy.fullname" . }}-job-priority
+          {{- end }}
     handling:
       assign:
         - "db-skip-locked"


### PR DESCRIPTION
Stumbled upon this today in dev-cancer instance:
```
galaxy.jobs.runners.kubernetes DEBUG 2021-03-09 01:04:28,639 Job.batch "gxy-try7-gxy-rls-7lvt2" is invalid: spec.template.spec.priorityClassName: Invalid value: "try7-gxy-rls-galaxy-job-priority \n": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```