### PR TITLE
Removing old scripts

### DIFF
--- a/galaxy/scripts/delete
+++ b/galaxy/scripts/delete
@@ -1,1 +1,0 @@
-helm delete --purge galaxy

--- a/galaxy/scripts/install
+++ b/galaxy/scripts/install
@@ -1,1 +1,0 @@
-helm install --name galaxy .

--- a/galaxy/scripts/test-install
+++ b/galaxy/scripts/test-install
@@ -1,7 +1,0 @@
-#! /usr/bin/env bash
-
-# Run this to time the process of launching galaxy with helm.
-
-# call the helm install script; then wait for localhost to be available
-time ./scripts/install && \
-	time until curl -LkIs localhost | grep -q  "HTTP/2 200"; do echo waiting for localhost; sleep 0.5; done;


### PR DESCRIPTION
I don't think any of these scripts work with helm 3 anyway, but even if we want to add them back, I'd suggest we put them under `galaxy-helm/scripts` not `galaxy-helm/galaxy/scripts` since it's a convenience script for us so no reason to have it be packaged as part of the pushed chart