### PR TITLE
Converter mapping to mulled container

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -427,6 +427,7 @@ jobs:
         - tool_ids:
             - sort1
             - Grouping1
+            - CONVERTER_interval_to_bed_0
           container:
             docker_container_id_override: {{ .Values.image.repository }}:{{ .Values.image.tag }}
             resource_set: small


### PR DESCRIPTION
This is likely a problem for all converters with requirements?
One option might be to change the `datatypes_conf.xml` file from:

`<registration converters_path="lib/galaxy/datatypes/converters"`

to a path on the NFS and copy `lib/galaxy/datatypes/converters` onto the NFS as we do `tools` dir.

Another option is to just overwrite all converters that have requirements to use the galaxy image (unless they do have real requirements). Here's a potential list:

```
/galaxy/server/lib/galaxy/datatypes/converters$ grep -irl "requirement" .
 
wig_to_bigwig_converter.xml
pdb_to_gro.xml
mol2_to_mol_converter.xml
smi_to_mol_converter.xml
fastqsolexa_to_qual_converter.xml
biom1_to_biom2.xml
fastq_to_fqtoc.xml
bz2_to_uncompressed.xml
interval_to_bed12_converter.xml
sdf_to_cml_converter.xml
tabular_to_csv.xml
mol2_to_smi_converter.xml
pbed_to_lped_converter.xml
gff_to_bgzip_converter.xml
csv_to_tabular.xml
fasta_to_bowtie_color_index_converter.xml
encodepeak_to_bgzip_converter.xml
smi_to_smi_converter.xml
fastqsolexa_to_fasta_converter.xml
smi_to_inchi_converter.xml
inchi_to_mol2_converter.xml
bed_gff_or_vcf_to_bigwig_converter.xml
fasta_to_tabular_converter.xml
interval_to_tabix_converter.xml
bcf_to_bcf_uncompressed_converter.xml
cram_to_bam_converter.xml
inchi_to_smi_converter.xml
mol2_to_cml_converter.xml
interval_to_bigwig_converter.xml
bed_to_interval_index_converter.xml
bed_to_tabix_converter.xml
interval_to_bgzip_converter.xml
mol_to_inchi_converter.xml
vcf_to_interval_index_converter.xml
interval_to_bed_converter.xml
bcf_uncompressed_to_bcf_converter.xml
fasta_to_bowtie_base_index_converter.xml
lped_to_fped_converter.xml
mol2_to_sdf_converter.xml
cml_to_smi_converter.xml
gff_to_tabix_converter.xml
bed_to_bgzip_converter.xml
pileup_to_interval_index_converter.xml
interval_to_bed6_converter.xml
sdf_to_inchi_converter.xml
mol_to_cml_converter.xml
encodepeak_to_tabix_converter.xml
mol_to_mol2_converter.xml
fasta_to_fai.xml
sdf_to_smi_converter.xml
wiggle_to_simple_converter.xml
bed_to_gff_converter.xml
fasta_to_2bit.xml
tabular_to_dbnsfp.xml
interval_to_bedstrict_converter.xml
picard_interval_list_to_bed6_converter.xml
trr_or_dcd_to_xtc.xml
xtc_or_trr_to_dcd.xml
cml_to_mol2_converter.xml
neostorezip_to_neostore_converter.xml
to_qname_sorted_bam.xml
inchi_to_mol_converter.xml
vcf_to_bgzip_converter.xml
interval_to_interval_index_converter.xml
smi_to_sdf_converter.xml
sam_to_bigwig_converter.xml
vcf_to_tabix_converter.xml
lped_to_pbed_converter.xml
inchi_to_sdf_converter.xml
pbed_ldreduced_converter.xml
vcf_to_vcf_bgzip_converter.xml
vcf_bgzip_to_tabix_converter.xml
tar_to_directory.xml
fasta_to_len.xml
cml_to_inchi_converter.xml
bedgraph_to_bigwig_converter.xml
cml_to_sdf_converter.xml
mol_to_smi_converter.xml
sam_to_unsorted_bam.xml
biom2_to_biom1.xml
len_to_linecount.xml
xtc_or_dcd_to_trr.xml
mol2_to_inchi_converter.xml
ref_to_seq_taxonomy_converter.xml
to_coordinate_sorted_bam.xml
sdf_to_mol2_converter.xml
smi_to_cml_converter.xml
smi_to_mol2_converter.xml
inchi_to_cml_converter.xml
bam_to_bai.xml
gro_to_pdb.xml
bam_to_bigwig_converter.xml
```