### PR TITLE
Copy converters

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -137,7 +137,7 @@ cp -anL /galaxy/server/config/tool_data_table_conf.xml.sample /galaxy/server/con
 cp -aruL /galaxy/server/tool-data {{.Values.persistence.mountPath}}/;
 cp -aruL /galaxy/server/tools {{.Values.persistence.mountPath}}/tools | true;
 cp -aruL /galaxy/server/lib/galaxy/datatypes/converters {{.Values.persistence.mountPath}}/lib/galaxy/datatypes/converters | true;
-sed 's#converters_path="lib/galaxy/datatypes/converters"#converters_path="{{.Values.persistence.mountPath}}/lib/galaxy/datatypes/converters"#g' /galaxy/server/config/datatypes_conf.xml.sample > /galaxy/server/database/config/datatypes_conf.xml
+sed 's#converters_path="lib/galaxy/datatypes/converters"#converters_path="{{.Values.persistence.mountPath}}/lib/galaxy/datatypes/converters"#g' /galaxy/server/config/datatypes_conf.xml.sample > {{.Values.persistence.mountPath}}/config/datatypes_conf.xml
 {{- end -}}
 
 {{/*

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -136,6 +136,8 @@ cp -anL /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config
 cp -anL /galaxy/server/config/tool_data_table_conf.xml.sample /galaxy/server/config/mutable/shed_tool_data_table_conf.xml;
 cp -aruL /galaxy/server/tool-data {{.Values.persistence.mountPath}}/;
 cp -aruL /galaxy/server/tools {{.Values.persistence.mountPath}}/tools | true;
+cp -aruL /galaxy/server/lib/galaxy/datatypes/converters {{.Values.persistence.mountPath}}/lib/galaxy/datatypes/converters | true;
+sed 's#converters_path="lib/galaxy/datatypes/converters"#converters_path="{{.Values.persistence.mountPath}}/lib/galaxy/datatypes/converters"#g' /galaxy/server/config/datatypes_conf.xml.sample > /galaxy/server/database/config/datatypes_conf.xml
 {{- end -}}
 
 {{/*

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -302,6 +302,7 @@ configs:
       sanitize_allowlist_file: "/galaxy/server/config/mutable/sanitize_allowlist.txt"
       tool_config_file: "/galaxy/server/config/tool_conf.xml{{if .Values.cvmfs.enabled}},{{.Values.cvmfs.main.mountPath}}/config/shed_tool_conf.xml{{end}}"
       shed_tool_config_file: "/galaxy/server/config/mutable/editable_shed_tool_conf.xml"
+      datatypes_config_file: "{{.Values.persistence.mountPath}}/config/datatypes_conf.xml"
       tool_data_table_config_path: |-
         {{ if .Values.cvmfs.enabled -}}
         {{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/byhand/location/tool_data_table_conf.xml


### PR DESCRIPTION
Interim solution to solve the problem for the k8s runner of converters that expect scripts but also have requirements and therefore use mulled containers. This should not be an issue with pulsar as the tool directory (and hence scripts) will be staged into the container if I understand correctly.