### PR TITLE
Upgrade to networking.k8s.io/v1

### DIFF
--- a/galaxy/templates/ingress-activity-canary.yaml
+++ b/galaxy/templates/ingress-activity-canary.yaml
@@ -7,10 +7,10 @@
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -39,9 +39,17 @@ spec:
         paths:
           - path: {{ $ingressPath }}/api/users/
             pathType: Prefix
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            backend:
+              service:
+                name: {{ $fullName }}-nginx
+                port:
+                  number: {{ $servicePort }}
+{{- else -}}
             backend:
               serviceName: {{ $fullName }}-nginx
               servicePort: {{ $servicePort }}
+{{- end }}
     {{- end }}
   {{- end }}
 ---

--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: ImplementationSpecific
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- else -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+{{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
The earlier semver compare was not working correctly on RKE.
In addition, `networking.k8s.io/v1beta1` has been available since k8s v1.14, so dropping `extension/v1beta1` seems safe as the current values format doesn't support the older one anyway. Also, `networking.k8s.io/v1` is available from k8s v1.18.