### PR TITLE
Rolling back version to 4.0.0

### DIFF
--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: galaxy
 type: application
-version: 4.0.0
+version: 4.0.0-rc.1
 appVersion: "21.01"
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: galaxy
 type: application
-version: 4.1.2
+version: 4.0.0
 appVersion: "21.01"
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png


### PR DESCRIPTION
As discussed earlier today, given the last few weeks has been a period of rapid development and given the introduction of some backwards incompatible changes, we're rolling back version to 4.0.0-rc.1 manually and removing the 4.x versions that have been automatically created in the edge repository. We will then avoid bumping versions until the official 21.01 release, with which we will coincide with the 4.0 release of the chart.