### PR TITLE
Disable metrics

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -69,7 +69,7 @@ jobHandlers:
     existingClass: ""
 
 metrics:
-  enabled: true
+  enabled: false
   annotations: {}
   podAnnotations: {}
   podSpecExtra: {}


### PR DESCRIPTION
Set `metrics.enabled=false` in the `values.yml` file since an influxdb needs to be configured and available, which is not the default case.