### PR TITLE
semverCompare Bug Fix

### DIFF
--- a/galaxy/templates/ingress-activity-canary.yaml
+++ b/galaxy/templates/ingress-activity-canary.yaml
@@ -8,9 +8,9 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $k8s_version := .Capabilities.KubeVersion.Version | toString }}
-{{- if semverCompare "^1.19-0" $k8s_version -}}
+{{- if semverCompare "^1.19.0-0" $k8s_version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare "^1.14-0" $k8s_version -}}
+{{- else if semverCompare "^1.14.0-0" $k8s_version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
 {{ fail "This chart requires Kubernetes v1.14 or later" }}
@@ -41,14 +41,15 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}/api/users/
+{{- if semverCompare "^1.19.0-0" $k8s_version }}
             pathType: Prefix
             backend:
-{{- if semverCompare "^1.19-0" $k8s_version }}
               service:
                 name: {{ $fullName }}-nginx
                 port:
                   number: {{ $servicePort }}
 {{- else }}
+            backend:
               serviceName: {{ $fullName }}-nginx
               servicePort: {{ $servicePort }}
 {{- end }}

--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -3,9 +3,9 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $k8s_version := .Capabilities.KubeVersion.Version | toString }}
-{{- if semverCompare "^1.19-0" $k8s_version -}}
+{{- if semverCompare "^1.19.0-0" $k8s_version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare "^1.14-0" $k8s_version -}}
+{{- else if semverCompare "^1.14.0-0" $k8s_version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
 {{ fail "This chart requires Kubernetes v1.14 or later" }}
@@ -37,14 +37,15 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+{{- if semverCompare "^1.19.0-0" $k8s_version }}
             pathType: ImplementationSpecific
             backend:
-{{- if semverCompare "^1.19-0" $k8s_version }}
               service:
                 name: {{ $fullName }}-nginx
                 port:
                   number: {{ $servicePort }}
 {{- else }}
+            backend:
               serviceName: {{ $fullName }}-nginx
               servicePort: {{ $servicePort }}
 {{- end }}

--- a/galaxy/templates/priorityclass-job.yaml
+++ b/galaxy/templates/priorityclass-job.yaml
@@ -1,12 +1,12 @@
 {{- if and .Values.jobs.priorityClass.enabled (not .Values.jobs.priorityClass.existingClass) }}
 {{- $k8s_version := .Capabilities.KubeVersion.Version | toString }}
-{{- if semverCompare "^1.17-0" $k8s_version }}
+{{- if semverCompare "^1.17.0-0" $k8s_version }}
 apiVersion: scheduling.k8s.io/v1
-{{- else if semverCompare "^1.14-0" $k8s_version }}
+{{- else if semverCompare "^1.14.0-0" $k8s_version }}
 apiVersion: scheduling.k8s.io/v1beta1
 {{ else }}
   {{ fail "This chart requires Kubernetes v1.14 or later"}}
-{{- end}}
+{{- end }}
 kind: PriorityClass
 metadata:
   name: {{ include "galaxy.pod-priority-class" . }}


### PR DESCRIPTION
- Fixes detecting GKE versions properly
- Fixes `Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Ingress.spec.rules[0].http.paths[0]): unknown field "pathType" in io.k8s.api.networking.v1beta1.HTTPIngressPath` in v1beta1