### PR TITLE
Change default to deploy postgres operator

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -191,9 +191,9 @@ affinity: {}
 
 postgresql:
   enabled: true
-  # Whether to deploy the postgresl operator. In general, we recommend installing the operator
-  # globally.
-  deploy: false
+  # Whether to deploy the postgresl operator.
+  # In general, we recommend installing the operator globally in production.
+  deploy: true
   # hostname and port of an existing database to use.
   existingDatabase:
   galaxyDatabaseUser: galaxydbuser


### PR DESCRIPTION
Continuing the idea that `helm galaxy .` should work out-of-the-box, I think we should be vocal about recommending to install postgres-operator globally and set it to `false` in our production situations, but keep it deployed by default so that a newcomer can get a running simple galaxy with the default values