### PR TITLE
Whitespace `k8s_persistent_volume_claims`

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -273,14 +273,14 @@ configs:
         load: galaxy.jobs.runners.kubernetes:KubernetesJobRunner
         k8s_use_service_account: true
         k8s_persistent_volume_claims: |-
-          {{ template "galaxy.pvcname" . -}}:{{.Values.persistence.mountPath}}
+          {{ template "galaxy.pvcname" . -}}:{{ .Values.persistence.mountPath -}}
           {{- if .Values.cvmfs.enabled -}}
           {{- range $key, $entry := .Values.cvmfs.galaxyPersistentVolumeClaims -}}
-          ,{{- template "galaxy.fullname" $ -}}-cvmfs-gxy-{{ $key }}-pvc:{{ $entry.mountPath }}
+          ,{{- template "galaxy.fullname" $ -}}-cvmfs-gxy-{{ $key }}-pvc:{{ $entry.mountPath -}}
           {{- end -}}
           {{- end -}}
-          {{- if .Values.initJob.downloadToolConfs.enabled }}
-          ,{{ template "galaxy.pvcname" . -}}/{{ .Values.initJob.downloadToolConfs.volume.subPath }}:{{ .Values.initJob.downloadToolConfs.volume.mountPath }}
+          {{- if .Values.initJob.downloadToolConfs.enabled -}}
+          ,{{ template "galaxy.pvcname" . -}}/{{ .Values.initJob.downloadToolConfs.volume.subPath }}:{{ .Values.initJob.downloadToolConfs.volume.mountPath -}}
           {{- end -}}
           {{- if .Values.extraVolumes -}}
           {{- template "galaxy.extra_pvc_mounts" . -}}


### PR DESCRIPTION
Better fix would be to handle this as a proper YAML list in the k8s runner, and expect it to be json/yaml text in XML (as are the other configs). I can PR that to the runner and this won't be necessary anymore