### PR TITLE
ExtraFiles tweaks

### DIFF
--- a/galaxy/templates/configmap-extra-files.yaml
+++ b/galaxy/templates/configmap-extra-files.yaml
@@ -15,8 +15,10 @@ kind: ConfigMap
 data:
 {{- end }}
   {{- include "galaxy.getFilenameFromPath" $key | nindent 2 }}: |
-  {{- if $entry.path }}
+  {{- if $entry.tpl }}
     {{- tpl (tpl $entry.content $) $ | nindent 4 }}
+  {{- else }}
+    {{- $entry.content | nindent 4 }}
   {{- end }}
 ---
 {{- end }}

--- a/galaxy/templates/configmap-extra-files.yaml
+++ b/galaxy/templates/configmap-extra-files.yaml
@@ -16,8 +16,6 @@ data:
 {{- end }}
   {{- include "galaxy.getFilenameFromPath" $key | nindent 2 }}: |
   {{- if $entry.path }}
-    {{- ($.Files.Get $entry.path) | nindent 4 }}
-  {{- else }}
     {{- tpl (tpl $entry.content $) $ | nindent 4 }}
   {{- end }}
 ---

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -583,6 +583,7 @@ extraFileMappings:
     applyToJob: false
     applyToWeb: true
     applyToWorkflow: false
+    tpl: true
     content: |
       <!DOCTYPE html>
       <html lang="en">


### PR DESCRIPTION
- Remove `.extraFileMappings.[].path` which was recently added. xref: https://github.com/galaxyproject/galaxy-helm/pull/297
- Add `.extraFileMappings.[].tpl` and make running content through `tpl` optional (javascript contains brackets, so this will make UI injections easier)