### PR TITLE
Upgrade postgres operator

### DIFF
--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.p
 dependencies:
     - name: postgres-operator
       repository: https://raw.githubusercontent.com/zalando/postgres-operator/master/charts/postgres-operator/
-      version: 1.6.2
+      version: 1.6.3
       alias: postgresql
       condition: postgresql.deploy
     - name: galaxy-cvmfs-csi


### PR DESCRIPTION
1.6.2 had the bug rotating postgres pods on a single node