### PR TITLE
Explicitly use temp dir to prevent defaulting to system tmp

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -312,6 +312,7 @@ configs:
           function: k8s_container_mapper
           docker_enabled: true
           docker_default_container_id: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          tmp_dir: true
     limits:
     - type: registered_user_concurrent_jobs
       value: 5


### PR DESCRIPTION
Otherwise, jobs could end up using the node's temp instead of galaxy's temp, resulting in running out of disk space on the node's root disk.