### PR TITLE
Chown NFS again in mounts

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -151,7 +151,8 @@ cp -anL /galaxy/server/config/data_manager_conf.xml.sample /galaxy/server/config
 cp -anL /galaxy/server/config/tool_data_table_conf.xml.sample /galaxy/server/config/mutable/shed_tool_data_table_conf.xml;
 cp -aruL /galaxy/server/tool-data {{.Values.persistence.mountPath}}/;
 cp -aruL /galaxy/server/tools {{.Values.persistence.mountPath}}/tools | true;
-echo "Done" > /galaxy/server/config/mutable/init_mounts_done_{{.Release.Revision}}
+echo "Done" > /galaxy/server/config/mutable/init_mounts_done_{{.Release.Revision}};
+. /galaxy/server/.venv/bin/activate && python -c "import os; [([os.chown(os.path.join(root, each), 101, 101) for each in dirs], [os.chown(os.path.join(root, each), 101, 101) for each in files]) for root, dirs, files in os.walk(\"{{.Values.persistence.mountPath}}\")];"
 {{- end -}}
 
 {{/*

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/galaxy_rules: {{ include (print $.Template.BasePath "/configmap-galaxy-rules.yaml") . | sha256sum }}
         checksum/galaxy_extras: {{ include (print $.Template.BasePath "/configmap-extra-files.yaml") . | sha256sum }}
     spec:
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Config files copied onto the NFS were ending up owned by root. This makes everything uniformly owned by 101 as is expected right now