### PR TITLE
Make NGINX serve static content directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ current default values can be found in `values.yaml` file.
 | `nginx.image.tag`                          | The Nginx version to pull.                                                                                                                                                                                 |
 | `nginx.image.repository`                   | Where to obtain the Nginx container.                                                                                                                                                                       |
 | `nginx.image.pullPolicy`                   | When Kubernetes will [pull](https://kubernetes.io/docs/concepts/containers/images/#updating-images) the Nginx image from the repository.                                                                   |
+| `nginx.galaxyStaticDir`                    | Location at which to copy Galaxy static content in the NGINX pod init container, for direct serving. Defaults to `/galaxy/server/static`                   |
+
 
 # Handlers
 

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -38,7 +38,7 @@ data:
             server_name galaxy;
 
             location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}static {
-                alias /galaxy/server/static;
+                alias {{ .Values.nginx.galaxyStaticDir }};
                 expires 24h;
             }
 

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -37,6 +37,11 @@ data:
             listen 80;
             server_name galaxy;
 
+            location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}static {
+                alias /galaxy/server/static;
+                expires 24h;
+            }
+
             location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }} {
                 uwsgi_pass {{ template "galaxy.fullname" . }}-uwsgi:4001;
                 uwsgi_param UWSGI_SCHEME $scheme;

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -14,6 +14,7 @@ data:
 
     http {
         default_type  application/octet-stream;
+        include /etc/nginx/mime.types;
         sendfile        on;
         keepalive_timeout  65;
         index   index.html index.php index.htm;

--- a/galaxy/templates/deployment-nginx.yaml
+++ b/galaxy/templates/deployment-nginx.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
             - name: static-dir
-              mountPath: /galaxy/server/static
+              mountPath: {{ .Values.nginx.galaxyStaticDir }}
               subPath: static
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}

--- a/galaxy/templates/deployment-nginx.yaml
+++ b/galaxy/templates/deployment-nginx.yaml
@@ -32,6 +32,14 @@ spec:
       {{- if .Values.webHandlers.podSpecExtra -}}
         {{- tpl (toYaml .Values.webHandlers.podSpecExtra) . | nindent 6 }}
       {{- end }}
+      initContainers:
+        - name: {{ .Chart.Name }}-init-static
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          volumeMounts:
+            - name: static-dir
+              mountPath: /tmp/galaxy
+          command: ['/bin/sh', '-c', 'cp -r /galaxy/server/static /tmp/galaxy/static;']
       containers:
         - name: {{ .Chart.Name }}-nginx
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
@@ -44,6 +52,9 @@ spec:
             - name: nginx-conf
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            - name: static-dir
+              mountPath: /galaxy/server/static
+              subPath: static
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}
             - name: galaxy-data
@@ -73,6 +84,8 @@ spec:
         - name: nginx-conf
           configMap:
             name: {{ template "galaxy.fullname" $ }}-nginx-conf
+        - name: static-dir
+          emptyDir: {}
         - name: galaxy-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -638,4 +638,5 @@ nginx:
     pullPolicy: IfNotPresent
   conf:
     client_max_body_size: 100g
+  galaxyStaticDir: "/galaxy/server/static"
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy-helm/issues/330 

`.Values.nginx.galaxyStaticDir` only affects where the static dir is mounted in the NGINX pod and where the `nginx.conf` expects to look. It is not related to the location in the Galaxy container image itself, which remains hardcoded.