### PR TITLE
Added initial support for tusd

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -69,6 +69,7 @@ data:
                 add_header X-Content-Type-Options nosniff;
             }
 
+{{ if .Values.tusd.enabled }}
             location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/upload/resumable_upload {
                 # Disable request and response buffering
                 proxy_request_buffering  off;
@@ -82,6 +83,7 @@ data:
                 client_max_body_size     0;
                 proxy_pass http://{{ template "galaxy.fullname" . }}-tusd:1080/files;
             }
+{{ end }}
         # end server
         }
     # end http

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -69,6 +69,19 @@ data:
                 add_header X-Content-Type-Options nosniff;
             }
 
+            location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/upload/resumable_upload {
+                # Disable request and response buffering
+                proxy_request_buffering  off;
+                proxy_buffering          off;
+                proxy_http_version       1.1;
+                # Add X-Forwarded-* headers
+                proxy_set_header X-Forwarded-Host $host;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header         Upgrade $http_upgrade;
+                proxy_set_header         Connection "upgrade";
+                client_max_body_size     0;
+                proxy_pass http://{{ template "galaxy.fullname" . }}-tusd:1080/files;
+            }
         # end server
         }
     # end http

--- a/galaxy/templates/deployment-tusd.yaml
+++ b/galaxy/templates/deployment-tusd.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "galaxy.fullname" . }}-tusd
+  labels:
+    {{- include "galaxy.labels" . | nindent 4 }}
+{{- with .Values.tusd.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.tusd.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "galaxy.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: galaxy-tusd-handler
+  template:
+    metadata:
+      labels:
+        {{- include "galaxy.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: galaxy-tusd-handler
+      annotations:
+        {{- with .Values.tusd.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "galaxy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.tusd.securityContext | nindent 8 }}
+      {{- if .Values.tusd.podSpecExtra -}}
+        {{- tpl (toYaml .Values.webHandlers.podSpecExtra) . | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-tusd
+          image: "{{ .Values.tusd.image.repository }}:{{ .Values.tusd.image.tag }}"
+          imagePullPolicy: {{ .Values.tusd.image.pullPolicy }}
+          args:
+            - "-host"
+            - "0.0.0.0"
+            - "-port"
+            - "1080"
+            - "-upload-dir={{ .Values.persistence.mountPath }}/tmp"
+            - '-hooks-http=http://{{ include "galaxy.fullname" . }}-nginx:{{ .Values.service.port }}{{ template "galaxy.add_trailing_slash" .Values.ingress.path }}api/upload/hooks'
+            - "-hooks-http-forward-headers=X-Api-Key,Cookie"
+          env:
+          {{ include "galaxy.podEnvVars" . }}
+          ports:
+            - name: tusd-http
+              containerPort: 1080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: tusd-http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: tusd-http
+          volumeMounts:
+            - name: galaxy-data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: galaxy-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "galaxy.pvcname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- .Values.extraVolumes | toYaml | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/galaxy/templates/deployment-tusd.yaml
+++ b/galaxy/templates/deployment-tusd.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.tusd.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,3 +92,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/galaxy/templates/service-tusd.yaml
+++ b/galaxy/templates/service-tusd.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.tusd.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     app.kubernetes.io/component: galaxy-tusd-handler
     {{- include "galaxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/galaxy/templates/service-tusd.yaml
+++ b/galaxy/templates/service-tusd.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "galaxy.fullname" . }}-tusd
+  labels:
+    {{- include "galaxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 1080
+    targetPort: tusd-http
+    protocol: TCP
+    name: tusd
+  selector:
+    app.kubernetes.io/component: galaxy-tusd-handler
+    {{- include "galaxy.selectorLabels" . | nindent 4 }}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -658,3 +658,17 @@ nginx:
       cpu: 2
       memory: 3G
       ephemeral-storage: 100Gi
+
+tusd:
+  replicaCount: 1
+  annotations: {}
+  podAnnotations: {}
+  podSpecExtra: {}
+  securityContext:
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+  image:
+    repository: tusproject/tusd
+    tag: v1.6.0
+    pullPolicy: IfNotPresent

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -660,6 +660,7 @@ nginx:
       ephemeral-storage: 100Gi
 
 tusd:
+  enabled: false
   replicaCount: 1
   annotations: {}
   podAnnotations: {}


### PR DESCRIPTION
This builds on @mvdbeek's fantastic work on integrating tus with Galaxy: https://github.com/galaxyproject/galaxy/pull/12656, by addingthe tusd daemon as an out-of-the-box component in the helm chart.

Things are at a point where tusd is receiving the requests, but something is slightly amiss with auth handling:

```
[tusd] 2021/10/12 14:06:23 Using '/galaxy/server/database/tmp' as directory storage.
[tusd] 2021/10/12 14:06:23 Using 0.00MB as maximum size.
[tusd] 2021/10/12 14:06:23 Using 'http://gxyarchivetest6-galaxy-nginx:8000/galaxy/api/upload/hooks' as the endpoint for hooks
[tusd] 2021/10/12 14:06:23 Enabled hook events: pre-create, post-create, post-receive, post-terminate, post-finish
[tusd] 2021/10/12 14:06:23 Using 0.0.0.0:1080 as address to listen.
[tusd] 2021/10/12 14:06:23 Using /files/ as the base path.
[tusd] 2021/10/12 14:06:23 Using /metrics as the metrics path.
[tusd] 2021/10/12 14:06:23 Supported tus extensions: creation,creation-with-upload,termination,concatenation,creation-defer-length
[tusd] 2021/10/12 14:06:23 You can now upload files to: http://0.0.0.0:1080/files/
[tusd] 2021/10/12 14:11:34 event="RequestIncoming" method="POST" path="" requestId="76a08832e52cef184ed906db1d5c4510"
[tusd] 2021/10/12 14:11:34 event="HookInvocationStart" type="pre-create" id=""
[tusd] 2021/10/12 14:11:34 event="ResponseOutgoing" status="403" method="POST" path="" error="pre-create hook failed: endpoint returned: 403 Forbidden" requestId="76a08832e52cef184ed906db1d5c4510"
```

session cookie not getting forwarded perhaps? Ping @mvdbeek 