### PR TITLE
Use function to optionally ceil requests and limits

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -260,3 +260,14 @@ Define extra persistent volumes
     {{- end }}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Get default value or max
+*/}}
+{{- define "galaxy.max_value" -}}
+  {{-  if gt (.default | int) (.max | int) }}
+    {{- .max | int }}
+  {{- else }}
+    {{- .default | int }}
+  {{- end }}
+{{- end }}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -484,6 +484,12 @@ jobs:
   priorityClass:
     enabled: true
     existingClass: ""
+  maxRequests:
+    cpu: 10
+    memory: 20 # in G
+  maxLimits:
+    cpu: 12
+    memory: 24 # in G
   rules:
     container_mapper_rules.yml:
       mappings:
@@ -558,39 +564,39 @@ jobs:
         resource_sets:
           small:
             requests:
-              cpu: 1
-              memory: 2G
+              cpu: '{{include "galaxy.max_value" (dict "default" 1 "max" .Values.jobs.maxRequests.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 2 "max" .Values.jobs.maxRequests.memory)}}G'
             limits:
-              cpu: 2
-              memory: 5G
+              cpu: '{{include "galaxy.max_value" (dict "default" 2 "max" .Values.jobs.maxLimits.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 5 "max" .Values.jobs.maxLimits.memory)}}G'
           medium:
             requests:
-              cpu: 2
-              memory: 4G
+              cpu: '{{include "galaxy.max_value" (dict "default" 2 "max" .Values.jobs.maxRequests.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 4 "max" .Values.jobs.maxRequests.memory)}}G'
             limits:
-              cpu: 4
-              memory: 10G
+              cpu: '{{include "galaxy.max_value" (dict "default" 4 "max" .Values.jobs.maxLimits.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 10 "max" .Values.jobs.maxLimits.memory)}}G'
           large:
             requests:
-              cpu: 4
-              memory: 8G
+              cpu: '{{include "galaxy.max_value" (dict "default" 4 "max" .Values.jobs.maxRequests.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 8 "max" .Values.jobs.maxRequests.memory)}}G'
             limits:
-              cpu: 8
-              memory: 16G
+              cpu: '{{include "galaxy.max_value" (dict "default" 8 "max" .Values.jobs.maxLimits.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 16 "max" .Values.jobs.maxLimits.memory)}}G'
           2xlarge:
             requests:
-              cpu: 12
-              memory: 20G
+              cpu: '{{include "galaxy.max_value" (dict "default" 10 "max" .Values.jobs.maxRequests.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 20 "max" .Values.jobs.maxRequests.memory)}}G'
             limits:
-              cpu: 12
-              memory: 24G
+              cpu: '{{include "galaxy.max_value" (dict "default" 12 "max" .Values.jobs.maxLimits.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 24 "max" .Values.jobs.maxLimits.memory)}}G'
           mlarge:
             requests:
-              cpu: 2
-              memory: 16G
+              cpu: '{{include "galaxy.max_value" (dict "default" 2 "max" .Values.jobs.maxRequests.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 16 "max" .Values.jobs.maxRequests.memory)}}G'
             limits:
-              cpu: 4
-              memory: 20G
+              cpu: '{{include "galaxy.max_value" (dict "default" 4 "max" .Values.jobs.maxLimits.cpu)}}'
+              memory: '{{include "galaxy.max_value" (dict "default" 20 "max" .Values.jobs.maxLimits.memory)}}G'
         default_resource_set: small
     k8s_container_mapper.py: |
       {{- (.Files.Get "files/rules/k8s_container_mapper.py") }}


### PR DESCRIPTION
Adds function to automatically max out requests and limits based on highest node available in cluster (thus ensuring all jobs are runnable, if admin deems it's better to let jobs try running with lower requests rather than having them stay unschedulable)

TODO: Add value in README table 