### PR TITLE
A few non-breaking customizations and PostgreSQL version bump

### DIFF
--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.p
 dependencies:
   - name: postgres-operator
     repository: https://raw.githubusercontent.com/zalando/postgres-operator/master/charts/postgres-operator/
-    version: 1.6.3
+    version: 1.7.0
     condition: postgresql.deploy
     alias: postgresql
     tags:

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -35,7 +35,7 @@ data:
         client_max_body_size {{ .Values.nginx.conf.client_max_body_size }};
 
         server {
-            listen 80;
+            listen {{ .Values.nginx.containerPort }};
             server_name galaxy;
 
             location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}static {

--- a/galaxy/templates/cronjob-maintenance.yaml
+++ b/galaxy/templates/cronjob-maintenance.yaml
@@ -26,7 +26,7 @@ spec:
               - {{ .Values.persistence.mountPath }}/tmp
               - '!' 
               - -newermt 
-              - '-{{ (index .Values "configs" "job_conf.yml" "runners" "k8s" "k8s_walltime_limit" | default 604800) }} seconds'
+              - -{{ (index .Values "configs" "job_conf.yml" "runners" "k8s" "k8s_walltime_limit" | default 604800) }} seconds
               - -type 
               - f
               - -exec

--- a/galaxy/templates/cronjob-maintenance.yaml
+++ b/galaxy/templates/cronjob-maintenance.yaml
@@ -21,12 +21,18 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             # delete all tmp files older than walltime limit
-            args:
+            command:
               - find
               - {{ .Values.persistence.mountPath }}/tmp
-              - \! -newermt '-{{ (index .Values "configs" "job_conf.yml" "runners" "k8s" "k8s_walltime_limit" | default 604800) }} seconds'
-              - -type f
-              - -exec rm {} \;
+              - '!' 
+              - -newermt 
+              - '-{{ (index .Values "configs" "job_conf.yml" "runners" "k8s" "k8s_walltime_limit" | default 604800) }} seconds'
+              - -type 
+              - f
+              - -exec
+              - rm 
+              - '{}'
+              - ;
             volumeMounts:
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}

--- a/galaxy/templates/deployment-nginx.yaml
+++ b/galaxy/templates/deployment-nginx.yaml
@@ -53,7 +53,7 @@ spec:
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
           ports:
             - name: galaxy-nginx
-              containerPort: 80
+              containerPort: {{ .Values.nginx.containerPort }}
               protocol: TCP
           volumeMounts:
             {{- range $key, $entry := .Values.extraFileMappings -}}

--- a/galaxy/templates/hapostgres/pgcluster.yaml
+++ b/galaxy/templates/hapostgres/pgcluster.yaml
@@ -22,6 +22,9 @@ spec:
     {{- if .Values.postgresql.persistence.storageClass }}
     storageClass: {{ .Values.postgresql.persistence.storageClass }}
     {{- end }}
+  {{- if and .Values.postgresql.persistence .Values.postgresql.persistence.extra -}}
+  {{- tpl (toYaml .Values.postgresql.persistence.extra) . | nindent 4 }}
+  {{- end }}
   {{- if and .Values.postgresql.operator .Values.postgresql.operator.operatorSpecExtra -}}
   {{- tpl (toYaml .Values.postgresql.operator.operatorSpecExtra) . | nindent 2 }}
   {{- end }}

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/galaxy_extras: {{ include (print $.Template.BasePath "/configmap-extra-files.yaml") . | sha256sum }}
     spec:
       securityContext:
-        runAsUser: 101
+        runAsUser: {{ .Values.setupJob.runAsUser }}
         runAsGroup: 101
         fsGroup: 101
       {{- with .Values.nodeSelector }}
@@ -152,7 +152,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsUser: 0
+        runAsUser: {{ .Values.setupJob.runAsUser }}
         runAsGroup: 101
         fsGroup: 101
       restartPolicy: OnFailure

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -152,9 +152,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsUser: {{ .Values.setupJob.runAsUser }}
-        runAsGroup: 101
-        fsGroup: 101
+        {{- toYaml .Values.setupJob.securityContext | nindent 8 }}
       restartPolicy: OnFailure
       containers:
         - name: {{ .Chart.Name }}-init-mounts

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -132,7 +132,10 @@ extraVolumeMounts: []
 
 setupJob:
   createDatabase: true
-  runAsUser: 0
+  securityContext:
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
   ttlSecondsAfterFinished: 10
   downloadToolConfs:
     enabled: true

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -132,6 +132,7 @@ extraVolumeMounts: []
 
 setupJob:
   createDatabase: true
+  runAsUser: 0
   ttlSecondsAfterFinished: 10
   downloadToolConfs:
     enabled: true
@@ -235,6 +236,12 @@ postgresql:
   nameOverride: galaxy-postgres
   persistence:
     enabled: true
+    #storageClass:
+    #size:
+    #extra:
+    #  selector:
+    #    matchLabels:
+    #      label-key: label-value
 
 cvmfs:
   repositories:
@@ -648,6 +655,7 @@ nginx:
     repository: nginx
     tag: latest
     pullPolicy: IfNotPresent
+  containerPort: 80
   conf:
     client_max_body_size: 100g
   resources:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -658,7 +658,7 @@ nginx:
     repository: nginx
     tag: latest
     pullPolicy: IfNotPresent
-  containerPort: 80
+  containerPort: 7080
   conf:
     client_max_body_size: 100g
   resources:


### PR DESCRIPTION
Hi, 
I've created this PR with a couple of small changes. 

Firstly, I added options to customize a few things, namely:
- `securityContext` in init-jobs
- listen port in nginx (both `containerPort` and listen port in nginx conf)

Both changes have default values configured in `values.yaml` corresponding to previous hardcoded values. Reason for this customization is that with Pod Security Policy enabled (which requires `runAsUser` to be set to non-root) some resources were not able to run. In addition, nginx must be run in unprivileged nginx container which requires `containerPort` to be set to number higher than 1024. 

Secondly, I changed the `args` in the `CronJob` to `command` and split into array. Previous command (args) definition did not work and always ended with error `"unknown option -type f"`. Now CronJob works. 

Third, I bumped postgreSQL version to higher one because newer version allows to specify selector on PVC. This means that administrator can create a static PV with a label and postgreSQL will create PVC that binds to this particular PV (handy when you do not want it to dynamically create PVC each time). In order to support this, I added in `pgcluster.yaml` one if, that correctly indents extra volume arguments (the other `if` statement indents only with 2 spaces which is probably meant for new key:value pairs, not to extend `volume` section.)

I would be happy if you accepted this PR, I am open to discussion. I have deployed a fully functional Galaxy with these modifications on restricted cluster and with static Persistent Volume bound by postgreSQL.
