### PR TITLE
Remove trailing slash from /api/users/ as it causes a redirect on AWS

### DIFF
--- a/galaxy/templates/ingress-activity-canary.yaml
+++ b/galaxy/templates/ingress-activity-canary.yaml
@@ -40,7 +40,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ trimSuffix "/" $ingressPath }}/api/users/
+          - path: {{ trimSuffix "/" $ingressPath }}/api/users
 {{- if semverCompare "^1.19.0-0" $k8s_version }}
             pathType: Prefix
             backend:


### PR DESCRIPTION
The trailing slash on `/api/users/` causes a redirect problem when trying to use BioBlend to create new Galaxy users on AWS instances.  I did not see this on GCP or Jetstream, but AWS will redirect calls to `/api/users/` to `/api/users` and BioBlend does not follow redirects.  I investigated supplying a PR to BioBlend, but this has been discussed and rejected before [1], and is a moot point since I was trying to `POST` data and the requests library changes `POST` to `GET` so any posted data is lost [2].  Unfortunately (or not) this behavior is allowed by RFC7231 [3].  Therefore the simplest solution is to simply remove the trailing slash, which does not seem to affect anything else.

Further testing is still needed.

1. https://github.com/galaxyproject/bioblend/pull/336
2. https://github.com/psf/requests/issues/5284
3. https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.2