### PR TITLE
Update values.yaml

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -407,7 +407,7 @@ configs:
       job_config_file: "/galaxy/server/config/job_conf.yml"
       builds_file_path: |-
         {{ if .Values.refdata.enabled }}
-        {{ .Values.refdata.galaxyPersistentVolumeClaims.data.mountPath}}/managed/location/builds.txt
+        {{- .Values.refdata.galaxyPersistentVolumeClaims.data.mountPath}}/managed/location/builds.txt
         {{- end }}
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
       workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"


### PR DESCRIPTION
I am getting the error (note the \n in the path):
```
galaxy.util.dbkeys ERROR 2022-06-08 21:58:08,548 [pN:job_handler_0,p:8,tN:MainThread] ERROR: Unable to read builds file: [Errno 2] No such file or directory: '/galaxy/server/database/tool-data/\n/cvmfs/data.galaxyproject.org/managed/location/builds.txt'
```
due to a blank line in the `builds_file_path` entry in the galaxy.yml file.  Changing `{{` to `{{-` eliminates the blank line and fixes the path.