### PR TITLE
Remove use of beta APIs used by older K8s versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Linting and deployment tests (w/ & w/out CVMFS) on K3S
+name: Linting and deployment test on K3S
 on:
   push:
     branches:
@@ -33,7 +33,7 @@ jobs:
       - name: Start k8s locally
         uses: jupyterhub/action-k3s-helm@v1
         with:
-          k3s-version: v1.19.10+k3s1 # releases:  https://github.com/k3s-io/k3s/tags
+          k3s-version: v1.21.14+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
       - name: Verify function of k8s, kubectl, and helm
         run: |
           echo "kubeconfig: $KUBECONFIG"
@@ -58,43 +58,3 @@ jobs:
       - name: Print workflow handler log
         run: bash -c "kubectl logs -n galaxy $(kubectl -n galaxy get pods | grep -o '[^ ]*galaxy-workflow[^ ]*')"
         if: always()
-  cvmfstest:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Helm
-        run: curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-      - name: Helm dep update
-        run: cd galaxy/ && helm dep update && cd ..
-      - name: Start k8s locally
-        uses: jupyterhub/action-k3s-helm@v1
-        with:
-          k3s-version: v1.19.10+k3s1 # releases:  https://github.com/k3s-io/k3s/tags
-
-      - name: Verify function of k8s, kubectl, and helm
-        run: |
-          echo "kubeconfig: $KUBECONFIG"
-          kubectl version
-          kubectl get pods --all-namespaces
-
-          helm version
-          helm list
-      - name: Helm repo add galaxy
-        run: helm repo add galaxy https://github.com/CloudVE/helm-charts/raw/master
-      - name: Helm install Galaxy
-        run: time bash -c 'helm install --create-namespace -n galaxy galaxy ./galaxy --set persistence.accessMode="ReadWriteOnce" --set persistence.size="5Gi" --set cvmfs.enabled=true --set cvmfs.deploy=true --set cvmfs.cache.preload.enabled=false --set cvmfs.cache.alienCache.enabled=false --set cvmfs.cache.localCache.enabled=true --set postgresql.deploy=true --set resources.requests.memory=0Mi,resources.requests.cpu=0m --set setupJob.downloadToolConfs.enabled=false --set cvmfs.repositories.cvmfs-gxy-cloud=cloud.galaxyproject.org --set cvmfs.galaxyPersistentVolumeClaims.cloud.storage=1Gi --set cvmfs.galaxyPersistentVolumeClaims.cloud.storageClassName=cvmfs-gxy-cloud --set cvmfs.galaxyPersistentVolumeClaims.cloud.mountPath=/cvmfs/cloud.galaxyproject.org --wait --timeout=600s'
-      - name: Get events
-        run: kubectl get events -n galaxy; kubectl get events -n csi-drivers
-        if: always()
-      - name: Print web handler log
-        run: bash -c "kubectl logs -n galaxy $(kubectl -n galaxy get pods | grep -o '[^ ]*galaxy-web[^ ]*')"
-        if: always()
-      - name: Print job handler log
-        run: bash -c "kubectl logs -n galaxy $(kubectl -n galaxy get pods | grep -o '[^ ]*galaxy-job[^ ]*')"
-        if: always()
-      - name: Print workflow handler log
-        run: bash -c "kubectl logs -n galaxy $(kubectl -n galaxy get pods | grep -o '[^ ]*galaxy-workflow[^ ]*')"
-        if: always()
-

--- a/galaxy/templates/cronjob-maintenance.yaml
+++ b/galaxy/templates/cronjob-maintenance.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "galaxy.fullname" . }}-maintenance
@@ -24,13 +24,13 @@ spec:
             command:
               - find
               - {{ .Values.persistence.mountPath }}/tmp
-              - '!' 
-              - -newermt 
+              - '!'
+              - -newermt
               - -{{ (index .Values "configs" "job_conf.yml" "runners" "k8s" "k8s_walltime_limit" | default 604800) }} seconds
-              - -type 
+              - -type
               - f
               - -exec
-              - rm 
+              - rm
               - '{}'
               - ;
             volumeMounts:

--- a/galaxy/templates/ingress-activity-canary.yaml
+++ b/galaxy/templates/ingress-activity-canary.yaml
@@ -6,14 +6,7 @@
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $k8s_version := .Capabilities.KubeVersion.Version | toString }}
-{{- if semverCompare "^1.19.0-0" $k8s_version }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare "^1.14.0-0" $k8s_version -}}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-{{ fail "This chart requires Kubernetes v1.14 or later" }}
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-activity-canary
@@ -41,18 +34,12 @@ spec:
       http:
         paths:
           - path: {{ trimSuffix "/" $ingressPath }}/api/users/
-{{- if semverCompare "^1.19.0-0" $k8s_version }}
             pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}-nginx
                 port:
                   number: {{ $servicePort }}
-{{- else }}
-            backend:
-              serviceName: {{ $fullName }}-nginx
-              servicePort: {{ $servicePort }}
-{{- end }}
     {{- end }}
   {{- end }}
 ---

--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -2,14 +2,7 @@
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $k8s_version := .Capabilities.KubeVersion.Version | toString }}
-{{- if semverCompare "^1.19.0-0" $k8s_version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare "^1.14.0-0" $k8s_version -}}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-{{ fail "This chart requires Kubernetes v1.14 or later" }}
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -38,18 +31,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-{{- if semverCompare "^1.19.0-0" $k8s_version }}
             pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}-nginx
                 port:
                   number: {{ $servicePort }}
-{{- else }}
-            backend:
-              serviceName: {{ $fullName }}-nginx
-              servicePort: {{ $servicePort }}
-{{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/galaxy/templates/priorityclass-job.yaml
+++ b/galaxy/templates/priorityclass-job.yaml
@@ -1,12 +1,5 @@
 {{- if and .Values.jobs.priorityClass.enabled (not .Values.jobs.priorityClass.existingClass) }}
-{{- $k8s_version := .Capabilities.KubeVersion.Version | toString }}
-{{- if semverCompare "^1.17.0-0" $k8s_version }}
 apiVersion: scheduling.k8s.io/v1
-{{- else if semverCompare "^1.14.0-0" $k8s_version }}
-apiVersion: scheduling.k8s.io/v1beta1
-{{ else }}
-  {{ fail "This chart requires Kubernetes v1.14 or later"}}
-{{- end }}
 kind: PriorityClass
 metadata:
   name: {{ include "galaxy.pod-priority-class" . }}


### PR DESCRIPTION
With these changes, specifically the change to CronJob (https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/), the minimum supported Kubernetes version for this chart will be 1.21. Given that 1.21 reached end-of-life for maintenance support in June 2022 (https://endoflife.date/kubernetes), this seems reasonable.

Removed the test that included CVMFS because it's no longer compatible with the newer K8s version; will be replaced as part of #359 with S3fs instead.