### PR TITLE
Use manage_db.sh init to create the database on first boot

### DIFF
--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -42,7 +42,7 @@ spec:
             - >
               if (ls /galaxy/server/config/mutable/ | grep -q "db_init_done*");
                 then /galaxy/server/manage_db.sh upgrade && echo "Done" > /galaxy/server/config/mutable/db_init_done_{{.Release.Revision}};
-                else (/galaxy/server/create_db.sh && echo "Done" > /galaxy/server/config/mutable/db_init_done_{{.Release.Revision}};);
+                else (/galaxy/server/manage_db.sh init && echo "Done" > /galaxy/server/config/mutable/db_init_done_{{.Release.Revision}};);
               fi;
           {{- else }}
           args:


### PR DESCRIPTION
The `create_db.sh` script was removed from 22.05 and is replaced with `manage_db.sh init`.