### PR TITLE
Extend ttl on init jobs

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -185,10 +185,10 @@ Creates shell commands for downloading and extracting archives if modified
 */}}
 {{- define "galaxy.extract-archive-if-changed-command" -}}
 if [ -f {{ .extractPath }}/{{ base .downloadUrl }}_timestamp ]; then
-  echo "File {{ .downloadUrl }} previously downloaded. Only downloading if changed...";
+  echo "File {{ .downloadUrl }} previously downloaded. Only downloading if changed, to {{ .extractPath }}...";
   wget -qO- --header="If-Modified-Since: `cat {{ .extractPath }}/{{ base .downloadUrl }}_timestamp`" {{ .downloadUrl }} | tar -xvz || echo File not changed, ignoring....;
 else
-  echo "File not previously downloaded. Downloading and extracting {{ .downloadUrl }}...";
+  echo "File not previously downloaded. Downloading and extracting {{ .downloadUrl }} to {{ .extractPath }}...";
   wget -qO- {{ .downloadUrl }} | tar -xvz || exit 1;
 fi;
 wget --server-response --spider {{ .downloadUrl }} 2>&1 | grep -i "Last-Modified: " | cut -c18- > {{ .extractPath }}/{{ base .downloadUrl }}_timestamp;

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -190,7 +190,7 @@ setupJob:
     runAsUser: 101
     runAsGroup: 101
     fsGroup: 101
-  ttlSecondsAfterFinished: 10
+  ttlSecondsAfterFinished: 300
   downloadToolConfs:
     enabled: true
     # Uses Galaxy's shared file system volume


### PR DESCRIPTION
Give ourselves a bit more time to catch the job logs in case they fail (which they do fairly often during dev).