### PR TITLE
Sets the mulled resolution cache lock dir to local

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -409,6 +409,7 @@ configs:
       interactivetools_base_path: "{{$host := index .Values.ingress.hosts 0}}{{$path := index $host.paths 0}}{{$path.path}}"
       id_secret:
       logo_src: 'static/favicon.png'
+      mulled_resolution_cache_lock_dir: "/galaxy/server/local/mulled_cache_lock"
       database_connection: postgresql://unused:because@overridden_by_envvar
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
       sanitize_allowlist_file: "/galaxy/server/config/mutable/sanitize_allowlist.txt"


### PR DESCRIPTION
The mulled cache lock dir is often accessed and it doesn't need to be on the shared file system. Then each galaxy process that needs it will have it's own and performance on local disk should be better than on the shared file system.

Helps with #399 .