### PR TITLE
Parameterize the name of the cvmfs storage class used.

### DIFF
--- a/galaxy/templates/pvc-refdata.yaml
+++ b/galaxy/templates/pvc-refdata.yaml
@@ -15,7 +15,7 @@ spec:
   volumeName: {{ include "galaxy.fullname" $ }}-refdata-gxy-pv
 {{- end }}
 {{- if eq $.Values.refdata.type "cvmfs" }}
-  storageClassName: {{ tpl .Values.cvmfs.storageClassName }}
+  storageClassName: {{ tpl .Values.cvmfs.storageClassName . }}
 {{- end }}
 ---
 {{- end }}

--- a/galaxy/templates/pvc-refdata.yaml
+++ b/galaxy/templates/pvc-refdata.yaml
@@ -15,7 +15,7 @@ spec:
   volumeName: {{ include "galaxy.fullname" $ }}-refdata-gxy-pv
 {{- end }}
 {{- if eq $.Values.refdata.type "cvmfs" }}
-  storageClassName: {{ $.Release.Name }}-cvmfs
+  storageClassName: {{ tpl .Values.cvmfs.storageClassName }}
 {{- end }}
 ---
 {{- end }}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -308,6 +308,7 @@ refdata:
 
 cvmfs:
   deploy: true
+  storageClassName: {{ $.Release.Name }}-cvmfs
 
 s3csi:
   deploy: false

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -308,7 +308,7 @@ refdata:
 
 cvmfs:
   deploy: true
-  storageClassName: {{ $.Release.Name }}-cvmfs
+  storageClassName: "{{ $.Release.Name }}-cvmfs"
 
 s3csi:
   deploy: false


### PR DESCRIPTION
There is a problem with CVMFS CSI storage class naming when deploying two or more Galaxy instances to the same cluster.  In particular the `pvc-refdata.yaml` template defines the `storageClassName` as `{{ $.Release.Name }}-cvmfs`.  The release name is passed to the `galaxy-cvmfs-csi-helm` chart which is responsible for creating the storage class.

However, the cvmfs csi driver can only be installed once.  If the driver is installed with the first deployment (call it galaxy1) then the storage class will be named `galaxy1-cvmfs` and the second deployment (call it galaxy2) won't be able to find it since it is looking for `galaxy2-cvmfs`.

If the csi driver is deployed independently the storage class will be named `galaxy-cvmfs-csi-cvmfs` and neither deployment will be able to find it.  There is currently no way to change the name of the storage class created as the `galaxy-cvmfs-csi-helm` chart also hard codes the name as `{{ $.Release.Name }}-cmfs`

Friends with https://github.com/CloudVE/galaxy-cvmfs-csi-helm/pull/19