### PR TITLE
Set docker_enabled only once

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -374,7 +374,7 @@ configs:
       environments:
         tpv_dispatcher:
           container_monitor: false
-          docker_enabled: false
+          docker_enabled: true
           runner: dynamic
           type: python
           function: map_tool_to_destination

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -374,7 +374,6 @@ configs:
       environments:
         tpv_dispatcher:
           container_monitor: false
-          docker_enabled: true
           runner: dynamic
           type: python
           function: map_tool_to_destination
@@ -537,6 +536,7 @@ jobs:
         k8s:
           runner: k8s
           params:
+            docker_enabled: "true"
             requests_cpu: "{cores}"
             requests_memory: "{mem}Gi"
             limits_cpu: "{cores}"

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -374,7 +374,7 @@ configs:
       environments:
         tpv_dispatcher:
           container_monitor: false
-          docker_enabled: true
+          docker_enabled: false
           runner: dynamic
           type: python
           function: map_tool_to_destination
@@ -506,7 +506,6 @@ jobs:
         default:
           params:
             container_monitor: false
-            docker_enabled: "true"
             docker_default_container_id: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             tmp_dir: "true"
           scheduling:


### PR DESCRIPTION
At the very least, having the `enable_docker` setting set twice in the default values file seems undesirable. On top of that, I don't think we run the chart with docker available much any more so disabling it by default seems like a reasonable option.