### PR TITLE
Upgrade Galaxy version to 23.0

### DIFF
--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: galaxy
 type: application
 version: 5.5.0
-appVersion: "22.05"
+appVersion: "23.0"
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 
 image:
   repository: quay.io/galaxyproject/galaxy-min
-  tag: 22.05
+  tag: "23.0"  # Value must be quoted
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -399,7 +399,6 @@ configs:
       interactivetools_shorten_url: true
       interactivetools_base_path: "{{$host := index .Values.ingress.hosts 0}}{{$path := index $host.paths 0}}{{$path.path}}"
       id_secret:
-      logo_src: 'static/favicon.png'
       mulled_resolution_cache_lock_dir: "/galaxy/server/local/mulled_cache_lock"
       database_connection: postgresql://unused:because@overridden_by_envvar
       integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"


### PR DESCRIPTION
The auto-built image doesn't work out of the box atm because the version of TPV is wrong (see https://github.com/galaxyproject/galaxy/pull/15647#issuecomment-1453926643), but using a manually built image confirms the upgrade is working.

There are two issues/discussion points I'd like to raise:
1. Should we consider versioning the chart in some way that mimics the Galaxy versions? If not, should this PR invoke a major version bump on the chart or something else?
2. The default TPV database seems too generous with the resources for many tools for smaller instances. This is particularly evident during the chart development lifecycle where it's difficult to get many jobs to run on small dev envs (eg, [FastQC requests 8 CPUs](https://github.com/galaxyproject/tpv-shared-database/blob/59db8c3d3af50a802005a0338a0771d9132df570/tools.yml#LL357-L358)). Perhaps we could add an ability in TPV to scale all the default resources by some factor that would then make the those resource requests more acceptable to a local environment?