### PR TITLE
Use S3 storage class name as defined in the values file.

### DIFF
--- a/galaxy/templates/pvc-refdata.yaml
+++ b/galaxy/templates/pvc-refdata.yaml
@@ -13,6 +13,7 @@ spec:
       storage: {{ .Values.refdata.pvc.size }}
 {{- if eq $.Values.refdata.type "s3csi" }}
   volumeName: {{ include "galaxy.fullname" $ }}-refdata-gxy-pv
+  storageClassName: {{ .Values.s3csi.storageClass.name }}
 {{- end }}
 {{- if eq $.Values.refdata.type "cvmfs" }}
   storageClassName: {{ tpl .Values.cvmfs.storageClassName . }}


### PR DESCRIPTION
The S3CSI storage class name is defined in the values file but not used when declaring the refdata PVC.  This results in the PVC using the default storage clas (at least on GCP).