### PR TITLE
Add a post-install hook to restart cvmfs csi pods

### DIFF
--- a/galaxy/templates/configmap-cvmfs-fix.yaml
+++ b/galaxy/templates/configmap-cvmfs-fix.yaml
@@ -7,10 +7,12 @@ metadata:
 data:
   cvmfs-fix.sh: |
     sleep 10;
-    while [ "$(kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscis' -l 'component=nodeplugin' -o custom-columns=STATUS:.status.phase --no-headers)" != "Running" ]; do
-      echo "Waiting on nodeplugin pod to enter 'Running' status.";
+    status=`kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscsi' -l 'component=nodeplugin' -o custom-columns=STATUS:.status.phase --no-headers | sort | uniq | tr -d '\n'`
+    while [ "$status" != "Running" ]; do
+      echo "Waiting on nodeplugin pod to enter 'Running' status. Currently '$status'.";
       sleep 1;
+      status=`kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscsi' -l 'component=nodeplugin' -o custom-columns=STATUS:.status.phase --no-headers | sort | uniq | tr -d '\n'`
     done && \
     echo "Deleting nodeplugin pods..."
-    kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscis' -l 'component=nodeplugin' -o name | xargs kubectl -n {{ .Release.Namespace }} delete && \
+    kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscsi' -l 'component=nodeplugin' -o name | xargs kubectl -n {{ .Release.Namespace }} delete && \
     echo "Deleted nodeplugin pods."

--- a/galaxy/templates/configmap-cvmfs-fix.yaml
+++ b/galaxy/templates/configmap-cvmfs-fix.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap-cvmfs-fix
+  labels:
+    {{- include "galaxy.labels" . | nindent 4 }}
+data:
+  cvmfs-fix.sh: |
+    sleep 10;
+    while [ "$(kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscis' -l 'component=nodeplugin' -o custom-columns=STATUS:.status.phase --no-headers)" != "Running" ]; do
+      echo "Waiting on nodeplugin pod to enter 'Running' status.";
+      sleep 1;
+    done && \
+    echo "Deleting nodeplugin pods..."
+    kubectl get pods -n {{ .Release.Namespace }} -l 'app=cvmfscis' -l 'component=nodeplugin' -o name | xargs kubectl -n {{ .Release.Namespace }} delete && \
+    echo "Deleted nodeplugin pods."

--- a/galaxy/templates/hook-cvmfs-fix.yaml
+++ b/galaxy/templates/hook-cvmfs-fix.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-post-install-cvmfs-fix-job"
+  labels:
+    {{- include "galaxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-post-install-cvmfs-fix-job"
+      labels:
+        {{- include "galaxy.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "galaxy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      restartPolicy: Never
+      containers:
+      - name: post-install-kubectl
+        image: bitnami/kubectl
+        command:
+          - "sh"
+          - "/script/cvmfs-fix.sh"
+        volumeMounts:
+            - name: kubectl-script
+              mountPath: "/script"
+      volumes:
+      - name: kubectl-script
+        configMap:
+          name: "{{ .Release.Name }}-configmap-cvmfs-fix"

--- a/galaxy/templates/rbac-job.yaml
+++ b/galaxy/templates/rbac-job.yaml
@@ -9,7 +9,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "delete"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
As a workaround for what's seemingly a bug in the CVMFS-CSI (see https://github.com/cvmfs-contrib/cvmfs-csi/issues/70), restarting the nodeplugin pods after the chart has installed seems to fix the volume mount issue so add a post-install hook that will kill the relevant nodeplugin pods. 

For the hook to work properly, must install the chart with `--wait` flag.