### PR TITLE
RabbitMQ protocol and port configurable as variables

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -171,7 +171,7 @@ Creates the bash command for the handlers to wait for init scripts
 {{- define "galaxy.init-container-wait-command" -}}
 until [ -f /galaxy/server/config/mutable/db_init_done_{{$.Release.Revision}} ]; do echo "waiting for DB initialization"; sleep 1; done;
 {{- if $.Values.rabbitmq.enabled }}
-until timeout 1 bash -c "echo > /dev/tcp/{{ template "galaxy-rabbitmq.fullname" $ }}/5672"; do echo "waiting for rabbitmq service"; sleep 1; done;
+until timeout 1 bash -c "echo > /dev/tcp/{{ template "galaxy-rabbitmq.fullname" $ }}/{{.Values.rabbitmq.port}}"; do echo "waiting for rabbitmq service"; sleep 1; done;
 {{- end }}
 until [ -f /galaxy/server/config/mutable/init_mounts_done_{{$.Release.Revision}} ]; do echo "waiting for copying onto NFS"; sleep 1; done;
 {{- if .Values.setupJob.downloadToolConfs.enabled }}
@@ -252,7 +252,7 @@ Define pod env vars
                   name: {{ tpl .Values.rabbitmq.existingSecret . }}
                   key: password
             - name: GALAXY_CONFIG_OVERRIDE_AMQP_INTERNAL_CONNECTION
-              value: amqp://$(GALAXY_RABBITMQ_USERNAME):$(GALAXY_RABBITMQ_PASSWORD)@{{ template "galaxy-rabbitmq.fullname" . }}
+              value: {{ .Values.rabbitmq.protocol }}://$(GALAXY_RABBITMQ_USERNAME):$(GALAXY_RABBITMQ_PASSWORD)@{{ template "galaxy-rabbitmq.fullname" . }}:{{ .Values.rabbitmq.port }}
 {{- end }}
 {{- end -}}
 

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -651,6 +651,8 @@ rabbitmq:
   deploy: true
   existingCluster:
   existingSecret: '{{ include "galaxy-rabbitmq.fullname" . }}-default-user'
+  protocol: amqp
+  port: 5672
   nameOverride: rabbitmq
   extraSpec: {}
   terminationGracePeriodSeconds: 90


### PR DESCRIPTION
A TLS-enabled RabbitMQ cluster is served on port 5671 by default. This helm should support port and protocol customization via helm values.

I've set the defaults to `amqp` and `5672` to keep the current behavior. 