### PR TITLE
Generate documentation from comments in the values.yaml file.

### DIFF
--- a/VALUES.md
+++ b/VALUES.md
@@ -1,0 +1,49 @@
+| Key | Description |
+| nameOverride | Partial override of the `galaxy.fullname`.  The `.Release.Name` will be prepended to generate the fullname. |
+| fullnameOverride | Fully override the `galaxy.fullname` |
+| image.repository | Repository containing the Galaxy image. |
+| image.tag | Galaxy Docker image tag (generally corresponds to the desired Galaxy version) |
+| image.pullPolicy | Galaxy image [pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images) |
+| imagePullSecrets | Secrets used to [access a Galaxy image from a private repository](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
+| trainingHook.enabled | Enable the GTN webhook to link references to tools in tutorials to the corresponding tool panel in Galaxy. |
+| trainingHook.url | The training material server used to service the training-material webhook. |
+| service.type | The Galaxy service type |
+| service.port | The port Galaxy is listening to |
+| service.nodePort | The external port exposed on each node |
+| metrics.enabled | Enable the metrics server. Defaults to `false` |
+| serviceAccount.create | Specifies whether a service account should be created |
+| serviceAccount.annotations | Annotations to add to the service account |
+| serviceAccount.name | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| rbac.enabled | Does the cluster use role based access control. |
+| securityContext.fsGroup | Security context and file system group used by jobs. |
+| persistence | Configure the PVC used by Galaxy for local storage. |
+| persistence.enabled | Persistence is enabled by default |
+| persistence.name | Name of the PVC to create |
+| persistence.storageClass | StorageClass for the PVC. Must support `ReadWriteMany`. |
+| persistence.existingClaim | The name of an existing PVC to use for persistence. |
+| setupJob | tasks to perform once after installation |
+| setupJob.createDatabase | create the database |
+| setupJob.securityContext.runAsUser | the setup jobs will run as this user |
+| setupJob.securityContext.runAsGroup | the `runAsUser` will belong to this group. |
+| setupJob.securityContext.fsGroup | the filesystem group |
+| setupJob.downloadToolConfs.archives.startup | A tar.gz publicly accessible archive containing AT LEAST conf files and XML tool wrappers. Meant to be enough for Galaxy handlers to startup |
+| setupJob.downloadToolConfs.archives.running | A tar.gz publicly accessible archive containing AT LEAST confs, tool wrappers, and scripts excluding test data. Meant to be enough for Galaxy handlers to run jobs. |
+| setupJob.downloadToolConfs.archives.full | A tar.gz publicly accessible archive containing the full `tools` directory, including each tool's test data. Meant to be enough to run automated tool-tests, fully mimicking CVMFS setup |
+| extraInitContainers | Allow users to specify extra init containers |
+| ingress.enabled | Should ingress be enabled. Defaults to `true` |
+| ingress.ingressClassName |  |
+| resources.requests | We recommend updating these based on the usage levels of the server. |
+| postgresql.deploy | Whether to deploy the postgresl operator. In general, we recommend installing the operator globally in production. |
+| postgresql.existingDatabase | hostname and port of an existing database to use. |
+| refdata | Configuration block for reference data |
+| refdata.enabled | Whether or not to mount cloud-hosted Galaxy reference data and tools. |
+| refdata.type | `s3fs` or `cvmfs`, determines the CSI to use for mounting reference data. `cvmfs` is the default and recommended for the time being. |
+| cvmfs | Configuration block if `cvmfs` is used as `refdata.type` |
+| cvmfs.deploy | Deploy the Galaxy-CVMFS-CSI Helm Chart. This is an optional dependency, and for production scenarios it should be deployed separately as a cluster-wide resource |
+| s3csi | Configuration block if `s3csi` is used as the `refdata.type` |
+| s3csi.deploy | Deploy the CSI-S3 Helm Chart. This is an optional dependency, and for production scenarios it should be deployed separately as a cluster-wide resource. |
+| useSecretConfigs | When this flag is set to true, all configs will be set in secrets, when it is set to false, all configs will be set in configmaps |
+| configs | All config files will be relative to `/galaxy/server/config/` directory |
+| configs.galaxy\.yml | Galaxy configuration. See the [Galaxy documentation](https://docs.galaxyproject.org/en/master/admin/config.html) for more information. |
+| jobs | Additional dynamic rules to map into the container. |
+| jobs.priorityClass.enabled | Assign a [priorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) to the dispatched jobs. |

--- a/VALUES.md
+++ b/VALUES.md
@@ -1,4 +1,5 @@
 | Key | Description |
+|-----|-------------|
 | nameOverride | Partial override of the `galaxy.fullname`.  The `.Release.Name` will be prepended to generate the fullname. |
 | fullnameOverride | Fully override the `galaxy.fullname` |
 | image.repository | Repository containing the Galaxy image. |

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -1,19 +1,34 @@
 # Default values for Galaxy.
 # Declare variables to be passed into your templates.
 
+#- Partial override of the `galaxy.fullname`.  The `.Release.Name` will be prepended to generate the fullname.
 nameOverride: ""
+#- Fully override the `galaxy.fullname`
 fullnameOverride: ""
 
 image:
+  #- Repository containing the Galaxy image.
   repository: quay.io/galaxyproject/galaxy-min
+  #- Galaxy Docker image tag (generally corresponds to the desired Galaxy version)
   tag: "23.0"  # Value must be quoted
+  #-  Galaxy image [pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images)
   pullPolicy: IfNotPresent
 
+#- Secrets used to [access a Galaxy image from a private repository](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 imagePullSecrets: []
 
+trainingHook:
+  #- Enable the GTN webhook to link references to tools in tutorials to the corresponding tool panel in Galaxy.
+  enabled: true
+  #- The training material server used to service the training-material webhook.
+  url: https://training.galaxyproject.org/training-material/
+
 service:
+  #- The Galaxy service type
   type: ClusterIP
+  #- The port Galaxy is listening to
   port: 8000
+  #- The external port exposed on each node
   nodePort: 30700
 
 workflowHandlers:
@@ -141,6 +156,7 @@ celeryBeat:
     timeoutSeconds: 10
 
 metrics:
+  #- Enable the metrics server. Defaults to `false`
   enabled: false
   annotations: {}
   podAnnotations: {}
@@ -151,25 +167,32 @@ metrics:
     pullPolicy: IfNotPresent
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  #- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  #- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  #- The name of the service account to use.
+  #- If not set and create is true, a name is generated using the fullname template
   name: ""
 
 rbac:
+  #- Does the cluster use role based access control.
   enabled: true
 
 securityContext:
+  #- Security context and file system group used by jobs.
   fsGroup: 101
 
+#- Configure the PVC used by Galaxy for local storage.
 persistence:
+  #- Persistence is enabled by default
   enabled: true
+  #- Name of the PVC to create
   name: galaxy-pvc
   annotations: {}
+  #- StorageClass for the PVC. Must support `ReadWriteMany`.
   storageClass: ""
+  #- The name of an existing PVC to use for persistence.
   existingClaim: null
   accessMode: ReadWriteMany
   size: 5Gi
@@ -184,11 +207,16 @@ extraVolumeMounts: []
 #   - name: shared-data
 #     mountPath: /mnt/project/shared-data
 
+#- tasks to perform once after installation
 setupJob:
+  #- create the database
   createDatabase: true
   securityContext:
+    #- the setup jobs will run as this user
     runAsUser: 101
+    #- the `runAsUser` will belong to this group.
     runAsGroup: 101
+    #- the filesystem group
     fsGroup: 101
   ttlSecondsAfterFinished: 300
   downloadToolConfs:
@@ -198,18 +226,19 @@ setupJob:
       subPath: cvmfsclone # on galaxy-data volume (avoid config, tools, lib, etc...)
       mountPath: /cvmfs/cloud.galaxyproject.org
     archives:
-      # A tar.gz publicly accessible archive containing AT LEAST conf files and XML tool wrappers.
-      # Meant to be enough for Galaxy handlers to startup
+      #- A tar.gz publicly accessible archive containing AT LEAST conf files and XML tool wrappers.
+      #- Meant to be enough for Galaxy handlers to startup
       startup: https://storage.googleapis.com/cloud-cvmfs/startup.tar.gz
-      # A tar.gz publicly accessible archive containing AT LEAST confs, tool wrappers, and scripts
-      # excluding test data.
-      # Meant to be enough for Galaxy handlers to run jobs.
+      #- A tar.gz publicly accessible archive containing AT LEAST confs, tool wrappers, and scripts
+      #- excluding test data.
+      #- Meant to be enough for Galaxy handlers to run jobs.
       running: https://storage.googleapis.com/cloud-cvmfs/partial.tar.gz
-      # A tar.gz publicly accessible archive containing the full `tools` directory,
-      # including each tool's test data.
-      # Meant to be enough to run automated tool-tests, fully mimicking CVMFS setup
+      #- A tar.gz publicly accessible archive containing the full `tools` directory,
+      #- including each tool's test data.
+      #- Meant to be enough to run automated tool-tests, fully mimicking CVMFS setup
       full: https://storage.googleapis.com/cloud-cvmfs/contents.tar.gz
 
+#- Allow users to specify extra init containers
 extraInitContainers: []
 #   - name: my-first-container
 #     applyToJob: true
@@ -239,7 +268,9 @@ extraEnv: []
   #   value: MY_VALUE
 
 ingress:
+  #- Should ingress be enabled. Defaults to `true`
   enabled: true
+  #-
   ingressClassName: nginx
   canary:
     enabled: true
@@ -253,13 +284,14 @@ ingress:
     - host: ~
       paths:
         - path: "/galaxy"
+        - path: "/training-material"
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
 resources:
-  # We recommend updating these based on the usage levels of the server
+  #- We recommend updating these based on the usage levels of the server.
   requests:
     cpu: 100m
     memory: 1G
@@ -277,10 +309,10 @@ affinity: {}
 
 postgresql:
   enabled: true
-  # Whether to deploy the postgresl operator.
-  # In general, we recommend installing the operator globally in production.
+  #- Whether to deploy the postgresl operator.
+  #- In general, we recommend installing the operator globally in production.
   deploy: true
-  # hostname and port of an existing database to use.
+  #- hostname and port of an existing database to use.
   existingDatabase:
   galaxyDatabaseUser: galaxydbuser
   galaxyConnectionParams: "?sslmode=require"
@@ -300,17 +332,25 @@ postgresql:
     #    matchLabels:
     #      label-key: label-value
 
+#- Configuration block for reference data
 refdata:
+  #- Whether or not to mount cloud-hosted Galaxy reference data and tools.
   enabled: true
+  #- `s3fs` or `cvmfs`, determines the CSI to use for mounting reference data.
+  #-`cvmfs` is the default and recommended for the time being.
   type: cvmfs
   pvc:
     size: 10Gi
 
+#- Configuration block if `cvmfs` is used as `refdata.type`
 cvmfs:
+  #- Deploy the Galaxy-CVMFS-CSI Helm Chart. This is an optional dependency, and for production scenarios it should be deployed separately as a cluster-wide resource
   deploy: true
   storageClassName: "{{ $.Release.Name }}-cvmfs"
 
+#- Configuration block if `s3csi` is used as the `refdata.type`
 s3csi:
+  #- Deploy the CSI-S3 Helm Chart. This is an optional dependency, and for production scenarios it should be deployed separately as a cluster-wide resource.
   deploy: false
   images:
     csi: cloudve/csi-s3:0.31.3
@@ -329,11 +369,11 @@ s3csi:
     usePrefix: true
     prefix: /galaxy/v1/data.galaxyproject.org
 
-# When this flag is set to true, all configs will be set in secrets,
-# when it is set to false, all configs will be set in configmaps
+#- When this flag is set to true, all configs will be set in secrets,
+#- when it is set to false, all configs will be set in configmaps
 useSecretConfigs: false
 
-# All files will be relative to `/galaxy/server/config/` directory
+#- All config files will be relative to `/galaxy/server/config/` directory
 configs:
   job_conf.yml:
     runners:
@@ -389,6 +429,9 @@ configs:
 #       value: 5
 #     - type: anonymous_user_concurrent_jobs
 #       value: 2
+
+  #- Galaxy configuration. See the [Galaxy documentation](https://docs.galaxyproject.org/en/master/admin/config.html)
+  #- for more information.
   galaxy.yml:
     galaxy:
       galaxy_url_prefix: "{{ .Values.ingress.path }}"
@@ -493,9 +536,10 @@ configs:
   tool_conf.xml: |
     {{- (.Files.Get "files/configs/tool_conf.xml") }}
 
-# Additional dynamic rules to map into the container.
+#- Additional dynamic rules to map into the container.
 jobs:
   priorityClass:
+    #- Assign a [priorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) to the dispatched jobs.
     enabled: true
     existingClass: ""
   rules:

--- a/scripts/values_table.py
+++ b/scripts/values_table.py
@@ -49,6 +49,8 @@ README_ORDER = ["fullnameOverride",
                 "jobs.",
                 "refdata.deploy",
                 "refdata.enabled",
+                "cvmfs",
+                "s3csi",
                 "refdata.",
                 "setupJob.",
                 "ingress.",
@@ -75,10 +77,12 @@ README_ORDER = ["fullnameOverride",
                 "postgresql.",
                 "s3csi.",
                 "tusd.",
+                "rabbitmq",
+                "trainingHook",
                 ]
 
 # Entries that should be ignored.
-ignored = [ ]
+ignored = [ 'startupProbe', 'readinesProbe', 'livenessProbe' ]
 
 longest_key = -1
 longest_desc = -1
@@ -120,6 +124,8 @@ def print_table():
                 numbered_order[full_key] = i
     for key in sorted(set(key_list), key=lambda d: numbered_order[d]):
         print_table_row(key)
+    # for key in README_ORDER:
+    #     print_table_row(key)
 
 # Prints a single row in the table.
 def print_table_row(key):
@@ -156,7 +162,7 @@ def parse_value(key, value, label=None):
         record_key('postgresql.enabled')
         return
 
-    if label in ignored:
+    if label in ignored or key in ignored:
         # print(f"Ignoring {label}")
         return
 

--- a/scripts/yamldoc.py
+++ b/scripts/yamldoc.py
@@ -75,6 +75,7 @@ def main(filename: str, chars: str):
     indent_stack = [ 0 ]
     key = ''
     print("| Key | Description |")
+    print("|-----|-------------|")
     while lp.hasNext():
         line = lp.getNext().rstrip()
         if line.lstrip().startswith(chars):

--- a/scripts/yamldoc.py
+++ b/scripts/yamldoc.py
@@ -1,0 +1,120 @@
+# This is NOT a YAML parser.  This script does the bare minimum to match
+# comments with keys but may get it wrong.  Output from this script MUST be
+# curated by a human.
+
+import sys
+import argparse
+
+# Character string used to indicate the comment is a YamlDoc comment.
+chars = '#-'
+
+
+class LineProvider:
+    '''
+    A simple iterator type class. Mostly needed because occasionally we need
+    to push a line back after searching for the end of a multi-line string.
+    Also collapses lines that end with '\' into a single line.
+    '''
+    def __init__(self, inputPath: str):
+        with open(inputPath) as f:
+            self._lines = f.read().splitlines()
+        self._current = 0
+        self._previous = None
+
+    def hasNext(self):
+        return self._current < len(self._lines)
+
+
+    def getNext(self):
+        self._previous = self._current
+        line = self._collect_line()
+        return line
+
+    def back(self):
+        if self._previous is not None:
+            self._current = self._previous
+        else:
+            self._current -= 1
+
+    def _next_line(self):
+        line = self._lines[self._current].rstrip(' ')
+        self._current += 1
+        return line
+
+    def _collect_line(self):
+        segments = []
+        collecting = True
+        while collecting and self.hasNext():
+            line = self._next_line()
+            if line.endswith('\\'):
+                line = line.rstrip('\\')
+            else:
+                collecting = False
+            segments.append(line)
+        return ' '.join(segments)
+
+
+
+def get_line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def print_table_row(path: list, key: str, comments: list):
+    key = key.replace('.', '\.')
+    if len(path) == 0:
+        full_path = key
+    else:
+        full_path = f"{'.'.join(path)}.{key}"
+    print(f"| {full_path} | { ' '.join(comments)} |")
+
+
+def main(filename: str, chars: str):
+    lp = LineProvider(filename)
+    path = []
+    doc_lines = []
+    indent_stack = [ 0 ]
+    key = ''
+    print("| Key | Description |")
+    while lp.hasNext():
+        line = lp.getNext().rstrip()
+        if line.lstrip().startswith(chars):
+            doc_lines.append(line.replace(chars, '').strip())
+            continue
+
+        if len(line.strip()) == 0 or line.lstrip().startswith('#'):
+            continue
+        indent = get_line_indent(line)
+        if indent > indent_stack[-1]:
+            indent_stack.append(indent)
+            path.append(key)
+        elif indent < indent_stack[-1]:
+            while indent != indent_stack[-1]:
+                indent_stack.pop()
+                path.pop()
+
+        if ':' in line:
+            kv = line.split(':')
+            key = kv[0].strip()
+            if len(doc_lines) > 0:
+                print_table_row(path, key, doc_lines)
+                doc_lines = []
+        # Skip over multi-line strings
+        if line.endswith('|') or line.endswith('|-') or line.endswith('>-'):
+            while lp.hasNext() and get_line_indent(line) >= indent:
+                line = lp.getNext()
+            # The above loop finds the first line that is NOT part of the
+            # multi-line string so we need to put that line back into the
+            # buffer.
+            lp.back()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="yamldoc",
+        description="Generate a Markdown table with descriptions of the YAML keys in a Helm Chart's vales.yaml file.",
+        epilog="Copyright 2023 The Galaxy Project"
+    )
+    parser.add_argument('filename', nargs=1)
+    parser.add_argument('-c', '--chars', default="#-")
+    args = parser.parse_args()
+    main(args.filename[0], args.chars)


### PR DESCRIPTION
Includes a very simple script that parses the `values.yaml` file and generates a markdown (GFM) table with keys that have been documented with a comment starting with the string `#-` (configurable).

I looked for other programs that could do this ([yamldoc](https://pypi.org/project/yamldoc/), [Frigate](https://github.com/rapidsai/frigate), and [Ruamel.yaml](https://pypi.org/project/ruamel.yaml/)), but they are all sub-optimal for our use case.

## Discussion Points

1. Do we want to proceed with this?
2. Does anyone care what string is used to introduce a documentation comment?

I don't think we need, or want to, document every value in the `values.yaml` file, but I think we do want to document Galaxy specific configuration values.

I have included a `VALUES.md` file to view the output of the script.  The markdown table could be pasted into the README, or the README could link to the VALUES.md file.