### PR TITLE
fix non-yaml config template set via values

### DIFF
--- a/galaxy/templates/configs-galaxy.yaml
+++ b/galaxy/templates/configs-galaxy.yaml
@@ -14,7 +14,7 @@ data:
   {{- range $key, $entry := .Values.configs -}}
   {{- if $entry -}}
   {{- $key | nindent 2 }}: |
-  {{- $original := (toYaml $entry) -}}
+  {{- $original := (ternary (toYaml $entry) $entry (hasSuffix ".yml" $key)) }}
   {{- $nomultiline := (regexReplaceAll "^^\\s*\\|\\n*" $original "") -}}
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
   {{- tpl (tpl $nowhitespace $) $ | nindent 4 -}}

--- a/galaxy/templates/configs-galaxy.yaml
+++ b/galaxy/templates/configs-galaxy.yaml
@@ -13,10 +13,10 @@ data:
 {{- end }}
   {{- range $key, $entry := .Values.configs -}}
   {{- if $entry -}}
-  {{- $key | nindent 2 }}: |
-  {{- $original := (ternary (toYaml $entry) $entry (hasSuffix ".yml" $key)) }}
-  {{- $nomultiline := (regexReplaceAll "^^\\s*\\|\\n*" $original "") -}}
-  {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
+  {{- $key | nindent 2 -}}: |
+  {{- $isYamlFile := (or (hasSuffix ".yml" $key)  (hasSuffix ".yaml" $key)) -}}
+  {{- $original := (ternary (toYaml $entry) $entry $isYamlFile) -}}
+  {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $original "{{$1}}") -}}
   {{- tpl (tpl $nowhitespace $) $ | nindent 4 -}}
   {{- end -}}
   {{- end -}}

--- a/galaxy/templates/configs-galaxy.yaml
+++ b/galaxy/templates/configs-galaxy.yaml
@@ -14,7 +14,7 @@ data:
   {{- range $key, $entry := .Values.configs -}}
   {{- if $entry -}}
   {{- $key | nindent 2 -}}: |
-  {{- $isYamlFile := (or (hasSuffix ".yml" $key)  (hasSuffix ".yaml" $key)) -}}
+  {{- $isYamlFile := (or (hasSuffix ".yml" (lower $key))  (hasSuffix ".yaml" (lower $key))) -}}
   {{- $original := (ternary (toYaml $entry) $entry $isYamlFile) -}}
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $original "{{$1}}") -}}
   {{- tpl (tpl $nowhitespace $) $ | nindent 4 -}}

--- a/galaxy/templates/configs-galaxy.yaml
+++ b/galaxy/templates/configs-galaxy.yaml
@@ -14,8 +14,9 @@ data:
   {{- range $key, $entry := .Values.configs -}}
   {{- if $entry -}}
   {{- $key | nindent 2 -}}: |
-  {{- $isYamlFile := (or (hasSuffix ".yml" (lower $key))  (hasSuffix ".yaml" (lower $key))) -}}
-  {{- $original := (ternary (toYaml $entry) $entry $isYamlFile) -}}
+  {{- /* Don't call toYaml on string objects, only on maps or other complex objects. */}}
+  {{- $isStringObject := (kindIs "string" $entry) -}}
+  {{- $original := (ternary $entry (toYaml $entry) $isStringObject) -}}
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $original "{{$1}}") -}}
   {{- tpl (tpl $nowhitespace $) $ | nindent 4 -}}
   {{- end -}}


### PR DESCRIPTION
Because `toYaml` function was applied to all of the configs set in values, non-yaml files passed as a string produced manifests with invalid yaml. In this patch I change the behavior to only convert to yaml data intended for files ending in ".yml".

### Reproduce:
Add non-Yaml, e.g. XML, file to `values.configs`. For example:
```
diff --git a/galaxy/values.yaml b/galaxy/values.yaml
index 6b600b6..12d6875 100644
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -492,6 +492,7 @@ configs:
     {{- (.Files.Get "files/configs/integrated_tool_panel.xml") }}
   tool_conf.xml: |
     {{- (.Files.Get "files/configs/tool_conf.xml") }}
+  "auth_conf.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<auth>\n   <authenticator>\n      <type>localdb</type>\n      <options>\n         <allow-password-change>true</allow-password-change>\n      </options>\n   </authenticator>\n</auth>"
 
 # Additional dynamic rules to map into the container.
 jobs:
```

Without the patch the template will produce invalid YAML (note the extra "-"):
```
# Source: galaxy/templates/configs-galaxy.yaml
apiVersion: v1
metadata:
  name: release-name-galaxy-configs
  labels:
    helm.sh/chart: galaxy-5.7.1
    app.kubernetes.io/name: galaxy
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "23.0"
    app.kubernetes.io/managed-by: Helm
kind: ConfigMap
data:
  auth_conf.xml: |
    -
      <?xml version="1.0" encoding="UTF-8"?>
      <auth>
         <authenticator>
            <type>localdb</type>
            <options>
               <allow-password-change>true</allow-password-change>
            </options>
         </authenticator>
      </auth>
```

### Testing:
To test the patch, I have generated all templates before and after the change:

1. `helm template --debug -s templates/configs-galaxy.yaml . > before_change.txt`
2. Apply the patch
3. `helm template --debug -s templates/configs-galaxy.yaml . > after_change.txt`
4. `~/projects/galaxy-helm/galaxy $ diff before_change.txt after_change.txt`. Only unnecessary indentation is gone, otherwise configs have the same content and are valid:

```
37,40c37,41
<       <containers_resolvers>
<         <explicit />
<         <mulled />
<       </containers_resolvers>
---
>     <containers_resolvers>
>       <explicit />
>       <mulled />
>     </containers_resolvers>
>     
211a213
>     
253,271c255,274
<       toolshed.g2.bx.psu.edu/repos/bgruening/diff/diff/3.7+galaxy0
<       toolshed.g2.bx.psu.edu/repos/bgruening/pharmcat/pharmcat/1.3.1+galaxy0
<       toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.7.1+galaxy0
<       toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1
<       toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/dexseq/dexseq/1.28.1+galaxy2
<       toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.20.1+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse_to_standalone/1.16.11+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse_to_standalone/1.16.11+galaxy1
<       toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.11+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.11+galaxy1
<       toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.6
<       toolshed.g2.bx.psu.edu/repos/iuc/meme_meme/meme_meme/5.0.5.0
<       toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1
<       toolshed.g2.bx.psu.edu/repos/iuc/prestor_abseq3/prestor_abseq3/0.6.2+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/5.0.2+galaxy3
<       toolshed.g2.bx.psu.edu/repos/iuc/seurat/seurat/4.1.0+galaxy0
<       toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1
---
>     toolshed.g2.bx.psu.edu/repos/bgruening/diff/diff/3.7+galaxy0
>     toolshed.g2.bx.psu.edu/repos/bgruening/pharmcat/pharmcat/1.3.1+galaxy0
>     toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.7.1+galaxy0
>     toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1
>     toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/dexseq/dexseq/1.28.1+galaxy2
>     toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.20.1+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse_to_standalone/1.16.11+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse_to_standalone/1.16.11+galaxy1
>     toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.11+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.11+galaxy1
>     toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.6
>     toolshed.g2.bx.psu.edu/repos/iuc/meme_meme/meme_meme/5.0.5.0
>     toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1
>     toolshed.g2.bx.psu.edu/repos/iuc/prestor_abseq3/prestor_abseq3/0.6.2+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/5.0.2+galaxy3
>     toolshed.g2.bx.psu.edu/repos/iuc/seurat/seurat/4.1.0+galaxy0
>     toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1
>     
418a422
>     
420,426c424,430
<       <?xml version="1.0"?>
<       <workflow_schedulers default="core">
<         <core id="core" />
<         <handlers default="schedulers">
<             <handler id="workflow_scheduler0" tags="schedulers"/>
<         </handlers>
<       </workflow_schedulers>
---
>     <?xml version="1.0"?>
>     <workflow_schedulers default="core">
>       <core id="core" />
>       <handlers default="schedulers">
>           <handler id="workflow_scheduler0" tags="schedulers"/>
>       </handlers>
>     </workflow_schedulers>
```

With the XML as a string in values.configs:
```
helm template --debug -s templates/configs-galaxy.yaml . > xmlstring_before_change.txt
helm template --debug -s templates/configs-galaxy.yaml . > xmlstring_after_change.txt
diff xmlstring_before_change.txt xmlstring_after_change.txt 


15,24c15,23
<     -
<       <?xml version="1.0" encoding="UTF-8"?>
<       <auth>
<          <authenticator>
<             <type>localdb</type>
<             <options>
<                <allow-password-change>true</allow-password-change>
<             </options>
<          </authenticator>
<       </auth>
---
>     <?xml version="1.0" encoding="UTF-8"?>
>     <auth>
>        <authenticator>
>           <type>localdb</type>
>           <options>
>              <allow-password-change>true</allow-password-change>
>           </options>
>        </authenticator>
>     </auth>
```

Unnecessary indentation and "-" is gone.