### PR TITLE
Only execute the hook-cvmfs-fix if CVMFS is actually enabled.

### DIFF
--- a/galaxy/templates/hook-cvmfs-fix.yaml
+++ b/galaxy/templates/hook-cvmfs-fix.yaml
@@ -1,3 +1,5 @@
+{{- if and .Values.refdata.enabled (eq .Values.refdata.type "cvmfs") }}
+  # Include the code you want to run when both conditions are met
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -33,3 +35,5 @@ spec:
       - name: kubectl-script
         configMap:
           name: "{{ .Release.Name }}-configmap-cvmfs-fix"
+{{- end }}
+


### PR DESCRIPTION
Adds a guard around the `hook-cvmfs-fix` template so it is only executed when CVMFS is enabled.  Mutually exclusive with [#441](https://github.com/galaxyproject/galaxy-helm/pull/441)

Closes #439 