### PR TITLE
Add max requests to gunicorn

### DIFF
--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -69,7 +69,7 @@ spec:
             '{{- if .Values.extraInitCommands -}}
              {{- tpl .Values.extraInitCommands $ | nindent 13 }};
              {{- end -}}
-             /galaxy/server/.venv/bin/gunicorn "galaxy.webapps.galaxy.fast_factory:factory()" --timeout {{ .Values.webHandlers.gunicorn.timeout | default 300 }} --pythonpath /galaxy/server/lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080 --workers={{ .Values.webHandlers.gunicorn.workers | default 1 }} --config python:galaxy.web_stack.gunicorn_config --preload {{ .Values.webHandlers.gunicorn.extraArgs | default "" }}']
+             /galaxy/server/.venv/bin/gunicorn "galaxy.webapps.galaxy.fast_factory:factory()" --timeout {{ .Values.webHandlers.gunicorn.timeout | default 300 }} --pythonpath /galaxy/server/lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080 --workers={{ .Values.webHandlers.gunicorn.workers | default 1 }} --config python:galaxy.web_stack.gunicorn_config --preload {{ .Values.webHandlers.gunicorn.extraArgs | default "" }} --max-requests {{ .Values.webHandlers.gunicorn.maxRequests | default "50000" }} --max-requests-jitter {{ .Values.webHandlers.gunicorn.maxRequestsJitter | default "10000" }}']
           {{- if .Values.webHandlers.startupProbe.enabled }}
           startupProbe:
             httpGet:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -79,6 +79,8 @@ webHandlers:
   gunicorn:
     timeout: 300
     workers: 1
+    maxRequests: 50000
+    maxRequestsJitter: 10000
     extraArgs: ""
 
 jobHandlers:


### PR DESCRIPTION
From @mvdbeek on: https://matrix.to/#/!rfLDbcWEWZapZrujix:gitter.im/$f-E-Kl-Cumt4tPAajzrka83yHLSrmVM7IbDkTQjwDQA?via=gitter.im&via=matrix.org

> we're using https://github.com/galaxyproject/usegalaxy-playbook/blob/5be97742d688a5b65762bd13064a9484f77f6671/env/main/group_vars/galaxyjobservers.yml#L44C11-L44C11 for that reason. I spent a good amount of time looking at this and could confirm a memory leak in the asyncio stack when there are (temporarily) a lot of concurrent connections. The memory allocated for these connections is never released and there's not much we can do, except for switching to hypercorn and trio instead of gunicorn + uvicorn + asyncio
that said 23.1 reduced steady-state memory consumption by about 2 fold. it doesn't change anything about the growing memory consumption with concurrent requests, but I thought I'd mention this
![image](https://github.com/galaxyproject/galaxy-helm/assets/2070605/b737851d-d906-4bd8-8ed0-00c4660b1ab0)
the big drop in memory consumption is when we added the relevant patches to 23.1 and added --max-requests
the individual web handler processes now rarely ever go beyond 1.2GB RSS