### PR TITLE
Ensure that one of the dependent jobs succeeded.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -51,6 +51,10 @@ jobs:
     needs: [ package-from-pr, package-from-manual ]
     name: Create a tag and GitHub release for this version.
     runs-on: ubuntu-latest
+    if: |
+      always() 
+      && contains(needs.*.result, 'success')
+      && !contains(needs.*.result, 'failure')
     steps:
       - name: Tag and release
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -61,4 +61,4 @@ jobs:
           version=v$(cat galaxy/Chart.yaml | grep ^version: | awk '{print $2}')
           git tag -a $version -m "Automatic release of $version"
           git push origin $version
-          gh release create $version --generate-notes
+          gh release create $version --generate-notes --latest


### PR DESCRIPTION
The `tag-and-release` job depends on the `package-from-pr` or `package-from-manual` jobs succeeding.  However, the packaging jobs are mutually exclusive so we need to test if one, but not both, have succeeded.

See [Stack Overflow](https://stackoverflow.com/questions/66343052/github-actions-or-operator-for-needs-clause)

Closes #452 