### PR TITLE
Add YAML document separators 

### DIFF
--- a/galaxy/templates/configmap-cvmfs-fix.yaml
+++ b/galaxy/templates/configmap-cvmfs-fix.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/galaxy/templates/configmap-extra-files.yaml
+++ b/galaxy/templates/configmap-extra-files.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $entry := .Values.extraFileMappings -}}
 {{- if $entry }}
+---
 apiVersion: v1
 metadata:
   # Extract the filename portion only
@@ -20,9 +21,9 @@ data:
   {{- else }}
     {{- $entry.content | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- end }}
 ---
-{{- end }}
-{{- end }}
 apiVersion: v1
 metadata:
   name: {{ include "galaxy.fullname" $ }}-probedb-py
@@ -32,5 +33,3 @@ kind: ConfigMap
 data:
   probedb.py: |
     {{- (.Files.Get "scripts/probedb.py") | nindent 4 }}
-
----

--- a/galaxy/templates/configmap-galaxy-rules.yaml
+++ b/galaxy/templates/configmap-galaxy-rules.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/galaxy/templates/configmap-grafana-dashboard.yaml
+++ b/galaxy/templates/configmap-grafana-dashboard.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.influxdb.enabled }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/galaxy/templates/configs-galaxy.yaml
+++ b/galaxy/templates/configs-galaxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 metadata:
   name: {{ include "galaxy.fullname" . }}-configs

--- a/galaxy/templates/cronjob-maintenance.yaml
+++ b/galaxy/templates/cronjob-maintenance.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/galaxy/templates/deployment-celery-beat.yaml
+++ b/galaxy/templates/deployment-celery-beat.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/deployment-celery.yaml
+++ b/galaxy/templates/deployment-celery.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -1,4 +1,5 @@
 {{- range $handler_num, $e := until (int $.Values.jobHandlers.replicaCount) }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -210,5 +211,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
----
 {{- end }}

--- a/galaxy/templates/deployment-metrics.yaml
+++ b/galaxy/templates/deployment-metrics.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.metrics.enabled }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/deployment-nginx.yaml
+++ b/galaxy/templates/deployment-nginx.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/deployment-tusd.yaml
+++ b/galaxy/templates/deployment-tusd.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.tusd.enabled -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/galaxy/templates/hook-cvmfs-fix.yaml
+++ b/galaxy/templates/hook-cvmfs-fix.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.refdata.enabled (eq .Values.refdata.type "cvmfs") }}
   # Include the code you want to run when both conditions are met
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/galaxy/templates/ingress-activity-canary.yaml
+++ b/galaxy/templates/ingress-activity-canary.yaml
@@ -6,6 +6,7 @@
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -42,4 +43,4 @@ spec:
                   number: {{ $servicePort }}
     {{- end }}
 {{- end }}
----
+

--- a/galaxy/templates/ingress-tusd.yaml
+++ b/galaxy/templates/ingress-tusd.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.tusd.enabled .Values.tusd.ingress.enabled -}}
 {{- $fullName := include "galaxy.fullname" . -}}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -38,4 +39,4 @@ spec:
           {{- end }}
     {{- end }}
   {{- end }}
----
+

--- a/galaxy/templates/ingress.yaml
+++ b/galaxy/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "galaxy.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -39,4 +40,3 @@ spec:
           {{- end }}
     {{- end }}
   {{- end }}
----

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/galaxy/templates/priorityclass-job.yaml
+++ b/galaxy/templates/priorityclass-job.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.jobs.priorityClass.enabled (not .Values.jobs.priorityClass.existingClass) }}
+---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/galaxy/templates/pv-s3fs.yaml
+++ b/galaxy/templates/pv-s3fs.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.refdata.enabled (eq .Values.refdata.type "s3csi") }}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/galaxy/templates/pvc-galaxy.yaml
+++ b/galaxy/templates/pvc-galaxy.yaml
@@ -1,4 +1,5 @@
 {{ if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -23,4 +24,3 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{ end }}
----

--- a/galaxy/templates/pvc-refdata.yaml
+++ b/galaxy/templates/pvc-refdata.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.refdata.enabled }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,5 +19,4 @@ spec:
 {{- if eq $.Values.refdata.type "cvmfs" }}
   storageClassName: {{ tpl .Values.cvmfs.storageClassName . }}
 {{- end }}
----
 {{- end }}

--- a/galaxy/templates/rabbitmqcluster.yaml
+++ b/galaxy/templates/rabbitmqcluster.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.rabbitmq.enabled (not .Values.rabbitmq.existingCluster) }}
+---
 apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:

--- a/galaxy/templates/rbac-job.yaml
+++ b/galaxy/templates/rbac-job.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.rbac.enabled }}
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/galaxy/templates/secret-galaxy.yaml
+++ b/galaxy/templates/secret-galaxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/galaxy/templates/service-galaxy.yaml
+++ b/galaxy/templates/service-galaxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/galaxy/templates/service-nginx.yaml
+++ b/galaxy/templates/service-nginx.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/galaxy/templates/service-tusd.yaml
+++ b/galaxy/templates/service-tusd.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.tusd.enabled -}}
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/galaxy/templates/serviceaccount.yaml
+++ b/galaxy/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
According to the [YAML specification](https://yaml.org/spec/1.2.2/) three dashes are used to separate YAML directives from the document content and are also used to mark the start of a document if the file (stream) contains more than one YAML document.  However, several templates include a document separator at the end of the file, which can cause odd syntax problems depending on the order Helm arranges the templates.  

This PR adds triple dashes to the top of each YAML document and removes extraneous appearances elsewhere. The document separator is optional if a file only contains one YAML document, but I have added them to all templates for completeness.