### PR TITLE
Set committer info for the GitHub bot

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -61,6 +61,8 @@ jobs:
            persist-credentials: false
       - name: Tag and release
         run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
           version=v$(cat galaxy/Chart.yaml | grep ^version: | awk '{print $2}')
           git tag -a $version -m "Automatic release of $version"
           git push origin $version


### PR DESCRIPTION
Set a `user.name` and `user.email` so the GitHub actions bot and push to the repo.

See https://pinsystem.co.uk/how-to-use-git-commit-in-github-actions

Closes #465 