### PR TITLE
Add enable flag to cron jobs

### DIFF
--- a/galaxy/templates/cronjob-maintenance.yaml
+++ b/galaxy/templates/cronjob-maintenance.yaml
@@ -10,6 +10,8 @@ spec:
   {{- if $cronjob.enabled }}
   schedule: {{ $cronjob.schedule | quote }}
   {{- else }}
+  # Set an impossible date so that the cronjob is still defined, but effectively disabled. 
+  #  This will allow the cronjob to be run manually if needed.
   schedule: "0 0 30 2 *"
   {{- end }}
   jobTemplate:

--- a/galaxy/templates/cronjob-maintenance.yaml
+++ b/galaxy/templates/cronjob-maintenance.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     {{- include "galaxy.labels" $ | nindent 4 }}
 spec:
+  {{- if $cronjob.enabled }}
   schedule: {{ $cronjob.schedule | quote }}
+  {{- else }}
+  schedule: "0 0 30 2 *"
+  {{- end }}
   jobTemplate:
     spec:
       template:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -272,6 +272,7 @@ cronJobs:
   #- Runs the maintenance.sh script to purge items in the Galaxy database that
   #- have been flagged as deleted.
   maintenance:
+    enabled: true
     schedule: "5 2 * * *"
     extraSettings:
       #- Purge items older than this.
@@ -287,6 +288,7 @@ cronJobs:
       - "{{ tpl .Values.cronJobs.maintenance.extraSettings.days $ }}"
   #- Remove files from the tmp directory that are older than the allowable wall time for a job
   tmpdir:
+    enabled: true
     schedule: "15 2 * * *"
     extraSettings:
       lastModified: '{{ index .Values "configs" "job_conf.yml" "runners" "k8s" "k8s_walltime_limit" | default 604800 }}'


### PR DESCRIPTION
Adds an `enable` flag to each `cronJob` so they can be enabled/disabled.  Disabling a cron job is done by setting the schedule to `"0 0 30 2 * *"`, that is Feb 30th.  Since that date will never occur the job is effectively disabled.  Setting the `enable` flag to true resets the `schedule` to the value defined in the `values.yaml` file.