### PR TITLE
Persist credentials and set GH_TOKEN for the GitHub command line tool

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -51,14 +51,14 @@ jobs:
     needs: [ package-from-pr, package-from-manual ]
     name: Create a tag and GitHub release for this version.
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     if: |
       always() 
       && contains(needs.*.result, 'success')
       && !contains(needs.*.result, 'failure')
     steps:
       - uses: actions/checkout@v4
-        with:
-           persist-credentials: false
       - name: Tag and release
         run: |
           git config user.name "GitHub Actions Bot"


### PR DESCRIPTION
Persist credentials from the `actions/checkout` step and set `GH_TOKEN` so the GitHub command line tool can push to the repository.

Hopefully, this *finally* closes #462