### PR TITLE
Checkout latest commit made by helm-ci action

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -59,6 +59,8 @@ jobs:
       && !contains(needs.*.result, 'failure')
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Tag and release
         run: |
           git config user.name "GitHub Actions Bot"


### PR DESCRIPTION
Ensure the `tag-and-release` job checks out the latest commits make by the `helm-ci` action.

Closes #472 
