### PR TITLE
Don't give read permission to the entire objects directory

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -10,7 +10,7 @@ image:
   #- Repository containing the Galaxy image.
   repository: quay.io/galaxyproject/galaxy-min
   #- Galaxy Docker image tag (generally corresponds to the desired Galaxy version)
-  tag: "24.0.2"  # Value must be quoted
+  tag: "24.1.1"  # Galaxy versions prior to 24.1.1 contain a bug mapping the extra_files directory
   #-  Galaxy image [pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images)
   pullPolicy: IfNotPresent
 
@@ -475,7 +475,6 @@ configs:
           {{- template "galaxy.pvcname" . -}}/tmp:{{ .Values.persistence.mountPath -}}/tmp:rw,
           {{- template "galaxy.pvcname" . -}}/tool-data:{{ .Values.persistence.mountPath -}}/tool-data:rw,
           {{- template "galaxy.pvcname" . -}}/tools:{{ .Values.persistence.mountPath -}}/tools:r,
-          {{- template "galaxy.pvcname" . -}}/objects:{{ .Values.persistence.mountPath -}}/objects:r,
           {{- template "galaxy.pvcname" . -}}/shed_tools:{{ .Values.persistence.mountPath -}}/shed_tools:r
           {{- if .Values.refdata.enabled -}}
           ,{{- template "galaxy.fullname" $ -}}-refdata-gxy-pvc/data.galaxyproject.org:/cvmfs/data.galaxyproject.org:r


### PR DESCRIPTION
Versions of Galaxy prior to 24.1.1 (to be released) contain a bug that did not mount the `extra_files` directories to jobs causing some tools to fail.  Once 24.1.1 is available we can merge this to restrict jobs so they can only read their inputs and only write to their output locations.

See [PR #18462](https://github.com/galaxyproject/galaxy/pull/18462)

Closes #480 
Closes #478 