### PR TITLE
Check that the appVersion matches version returned by /api/version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,3 +64,21 @@ jobs:
       - name: Print workflow handler log
         run: bash -c "kubectl logs -n galaxy $(kubectl -n galaxy get pods | grep -o '[^ ]*galaxy-workflow[^ ]*')"
         if: always()
+      - name: Print service info
+        run: kubectl get svc -n galaxy
+        if: always()
+      - name: Print nginx service info
+        run: kubectl describe svc -n galaxy galaxy-nginx
+        if: always()
+      - name: Check appVersion
+        if: always()
+        run: |
+          appVersion=$(cat galaxy/Chart.yaml | grep ^appVersion: | awk '{print $2}' | tr -d '"')
+          address=$(kubectl get svc -n galaxy galaxy-nginx -o jsonpath="http://{.spec.clusterIP}:{.spec.ports[0].port}/galaxy/api/version")
+          echo "Address is $address"
+          apiVersion=$(curl $address | jq -r '"\(.version_major).\(.version_minor)"')
+          echo "appVersion: $appVersion"          
+          echo "apiVersion: $apiVersion"
+          if [ "$appVersion" != "$apiVersion" ]; then
+            exit 1
+          fi  

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,15 +64,11 @@ jobs:
       - name: Print workflow handler log
         run: bash -c "kubectl logs -n galaxy $(kubectl -n galaxy get pods | grep -o '[^ ]*galaxy-workflow[^ ]*')"
         if: always()
-      - name: Print service info
-        run: kubectl get svc -n galaxy
-        if: always()
-      - name: Print nginx service info
-        run: kubectl describe svc -n galaxy galaxy-nginx
-        if: always()
       - name: Check appVersion
         if: always()
         run: |
+          kubectl get svc -n galaxy
+          kubectl describe svc -n galaxy galaxy-nginx
           appVersion=$(cat galaxy/Chart.yaml | grep ^appVersion: | awk '{print $2}' | tr -d '"')
           address=$(kubectl get svc -n galaxy galaxy-nginx -o jsonpath="http://{.spec.clusterIP}:{.spec.ports[0].port}/galaxy/api/version")
           echo "Address is $address"

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: galaxy
 type: application
 version: 5.14.3
-appVersion: "24.0.2"
+appVersion: "24.1.1"
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:


### PR DESCRIPTION
I frequently forget to update the `appVersion` in the `Chart.yaml` when the Galaxy version changes.  This PR adds a test that compares the `appVersion` in the `Chart.yaml` with the version info returned by the `/api/version` endpoint and fails if they are not the same.