### PR TITLE
Set the name of the CVMFS alien cache

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -430,6 +430,11 @@ cvmfs:
   #- Deploy the Galaxy-CVMFS-CSI Helm Chart. This is an optional dependency, and for production scenarios it should be deployed separately as a cluster-wide resource
   deploy: true
   storageClassName: "{{ $.Release.Name }}-cvmfs"
+  cvmfscsi:
+    cache:
+      alien:
+        pvc:
+          name: cvmfs-alien-cache
 
 #- Configuration block if `s3csi` is used as the `refdata.type`
 s3csi:


### PR DESCRIPTION
This name mismatch trips up quite a few users. For example, possibly #496 

Should we set the cache name here?  Or should we not change the name in the [galaxy-cvmfs-csi](https://github.com/CloudVE/galaxy-cvmfs-csi-helm/blob/a75a195396710bfc50dab3fb227330dea3a0c3a2/galaxy-cvmfs-csi/values.yaml#L36) chart?  The [upstream chart](https://github.com/cvmfs-contrib/cvmfs-csi/blob/f1b4983caeb767ea85f8b041ac1ab284b4e9251f/deployments/helm/cvmfs-csi/values.yaml#L47) uses `cvmfs-alien-cache`.

Closes #437 