### PR TITLE
Parameterize the image used for init containers.

### DIFF
--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -27,7 +27,8 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: {{ .Chart.Name }}-wait-postgres
-          image: alpine:3.16
+          image: {{ .Values.jobs.init.image.repository }}:{{ .Values.jobs.init.image.tag }}
+          imagePullPolicy: {{ .Values.jobs.init.image.pullPolicy }}
           command: ['sh', '-c', 'echo Chown mount path; chown 101:101 {{ .Values.persistence.mountPath }}; echo Begin waiting for postgres; until nc -z -w3 {{ template "galaxy-postgresql.fullname" . }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done; echo done;']
           volumeMounts:
             - name: galaxy-data
@@ -198,7 +199,8 @@ spec:
             {{- end }}
 {{ if .Values.setupJob.downloadToolConfs.enabled }}
         - name: {{ .Chart.Name }}-init-cloud-repo
-          image: alpine:3.16
+          image: {{ .Values.jobs.init.image.repository }}:{{ .Values.jobs.init.image.tag }}
+          imagePullPolicy: {{ .Values.jobs.init.image.pullPolicy }}
           command: ['sh', '-c', '{{- include "galaxy.extract-archive-if-changed-command" (dict "extractPath" .Values.setupJob.downloadToolConfs.volume.mountPath "downloadUrl" .Values.setupJob.downloadToolConfs.archives.startup) -}} && echo "Done" > /galaxy/server/config/mutable/init_clone_done_{{.Release.Revision}}']
           volumeMounts:
             - name: galaxy-data
@@ -208,14 +210,16 @@ spec:
               mountPath: /galaxy/server/config/mutable/
               subPath: config
         - name: {{ .Chart.Name }}-init-cloud-repo-partial
-          image: alpine:3.16
+          image: {{ .Values.jobs.init.image.repository }}:{{ .Values.jobs.init.image.tag }}
+          imagePullPolicy: {{ .Values.jobs.init.image.pullPolicy }}
           command: ['sh', '-c', '{{- include "galaxy.extract-archive-if-changed-command" (dict "extractPath" .Values.setupJob.downloadToolConfs.volume.mountPath "downloadUrl" .Values.setupJob.downloadToolConfs.archives.running) -}}']
           volumeMounts:
             - name: galaxy-data
               mountPath: {{ .Values.setupJob.downloadToolConfs.volume.mountPath }}
               subPath: {{ .Values.setupJob.downloadToolConfs.volume.subPath }}
         - name: {{ .Chart.Name }}-init-cloud-repo-full
-          image: alpine:3.16
+          image: {{ .Values.jobs.init.image.repository }}:{{ .Values.jobs.init.image.tag }}
+          imagePullPolicy: {{ .Values.jobs.init.image.pullPolicy }}
           command: ['sh', '-c', '{{- include "galaxy.extract-archive-if-changed-command" (dict "extractPath" .Values.setupJob.downloadToolConfs.volume.mountPath "downloadUrl" .Values.setupJob.downloadToolConfs.archives.full) -}}']
           volumeMounts:
             - name: galaxy-data

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -654,6 +654,12 @@ configs:
 
 #- Additional dynamic rules to map into the container.
 jobs:
+  init:
+    #- The Docker image to use for the init containers
+    image:
+      repository: alpine
+      tag: 3.16
+      pullPolicy: IfNotPresent
   priorityClass:
     #- Assign a [priorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) to the dispatched jobs.
     enabled: true


### PR DESCRIPTION
Most images used can be specified, and overridden, in the `values.yaml` file.  Except the images used in the init containers in the `jobs_init.yaml` template.

This PR parameterizes those images (four in total) as well.  The only issue to be settled is where in the `values.yaml` file these should be specified.  For now I have added them under the `jobs` block:
```
#- Additional dynamic rules to map into the container.
jobs:
  init:
    #- The Docker image to use for the init containers
    image:
      repository: alpine
      tag: 3.16
      pullPolicy: IfNotPresent
```
Closes #499 
