### PR TITLE
Update dependency charts; save outputs to working dir

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Start k8s locally
         uses: jupyterhub/action-k3s-helm@v3
         with:
-          k3s-version: v1.28.7+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
+          k3s-version: v1.30.4+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
           metrics-enabled: false
           traefik-enabled: false
       - name: Verify function of k8s, kubectl, and helm
@@ -73,8 +73,8 @@ jobs:
           address=$(kubectl get svc -n galaxy galaxy-nginx -o jsonpath="http://{.spec.clusterIP}:{.spec.ports[0].port}/galaxy/api/version")
           echo "Address is $address"
           apiVersion=$(curl $address | jq -r '"\(.version_major).\(.version_minor)"')
-          echo "appVersion: $appVersion"          
+          echo "appVersion: $appVersion"
           echo "apiVersion: $apiVersion"
           if [ "$appVersion" != "$apiVersion" ]; then
             exit 1
-          fi  
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,6 @@ galaxy/charts/
 
 # IDEs
 .idea
+.vscode
 
 Chart.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ansible.python.interpreterPath": "/Users/ea/opt/anaconda3/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "ansible.python.interpreterPath": "/Users/ea/opt/anaconda3/bin/python"
-}

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -22,14 +22,14 @@ dependencies:
       - deploy-s3csi
   - name: galaxy-cvmfs-csi
     repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
-    version: 2.4.0
+    version: 2.5.0
     condition: cvmfs.deploy
     alias: cvmfs
     tags:
       - deploy-cvmfs
   - name: rabbitmq-cluster-operator
     repository: https://charts.bitnami.com/bitnami
-    version: 2.6.12
+    version: 2.10.0
     condition: rabbitmq.deploy
     alias: rabbitmq
     tags:

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.p
 dependencies:
   - name: postgres-operator
     repository: https://raw.githubusercontent.com/zalando/postgres-operator/master/charts/postgres-operator/
-    version: 1.9.0
+    version: 1.13.0
     condition: postgresql.deploy
     alias: postgresql
     tags:

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -22,14 +22,14 @@ dependencies:
       - deploy-s3csi
   - name: galaxy-cvmfs-csi
     repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
-    version: 2.5.0
+    version: 2.5.1
     condition: cvmfs.deploy
     alias: cvmfs
     tags:
       - deploy-cvmfs
   - name: rabbitmq-cluster-operator
     repository: https://charts.bitnami.com/bitnami
-    version: 4.3.22
+    version: 4.3.25
     condition: rabbitmq.deploy
     alias: rabbitmq
     tags:

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
       - deploy-cvmfs
   - name: rabbitmq-cluster-operator
     repository: https://charts.bitnami.com/bitnami
-    version: 2.10.0
+    version: 4.3.22
     condition: rabbitmq.deploy
     alias: rabbitmq
     tags:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -565,6 +565,7 @@ configs:
         {{- end }}
       tool_dependency_dir: "{{.Values.persistence.mountPath}}/deps"
       job_config_file: "/galaxy/server/config/job_conf.yml"
+      outputs_to_working_directory: true
       builds_file_path: |-
         {{ if .Values.refdata.enabled }}
         /cvmfs/data.galaxyproject.org/managed/location/builds.txt


### PR DESCRIPTION
I tested the updated deps on a K32 (1.30) cluster and worked as expected.

The outputs_to_working_directory option was a conclusion from a recent discussion.