### PR TITLE
Update readme for file system upgrade; bump Galaxy release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Helm dep update for galaxy
-        run: cd galaxy/ && helm dep update && cd ..
       - name: Helm linting for galaxy
         run: helm lint galaxy/
 
@@ -30,12 +28,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Helm dep update for galaxy
-        run: cd galaxy/ && helm dep update && cd ..
       - name: Start k8s locally
         uses: jupyterhub/action-k3s-helm@v3
         with:
-          k3s-version: v1.30.4+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
+          k3s-version: v1.32.0+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
           metrics-enabled: false
           traefik-enabled: false
       - name: Verify function of k8s, kubectl, and helm

--- a/README.md
+++ b/README.md
@@ -516,11 +516,12 @@ See the `example` cron job included in the `values.yaml` file for a full example
 * v6 replaces the [Zalando Postgres
   operator](https://github.com/zalando/postgres-operator) with
   [CloudNativePG](https://cloudnative-pg.io/) operator for Postgres. This
-  decision was made because CloudNativePG is a [CNCF](https://www.cncf.io/)
-  project, has increasing popularity, and the avoidance of StatefulSets makes
-  management easier. However, there is no direct upgrade path from Zalando to
-  CloudNativePG. Therefore, **simply upgrading the Galaxy Helm chart could
-  result in your existing database being deleted and possible data loss**.
+  decision was made because CloudNativePG is meant to become a
+  [CNCF](https://www.cncf.io/) project, has increasing popularity, and the
+  avoidance of StatefulSets makes management easier. However, there is no direct
+  upgrade path from Zalando to CloudNativePG. Therefore, **simply upgrading the
+  Galaxy Helm chart could result in your existing database being deleted and
+  possible data loss**.
 
   We recommend first creating a [logical
   backup](https://github.com/zalando/postgres-operator/blob/master/docs/administrator.md#logical-backups)

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ See the `example` cron job included in the `values.yaml` file for a full example
   existing database.
 
 * v6 chart also changes the default uid of the system Galaxy user. Previously
-  this uid was 101, which is a privileged uid and has caused conflicts. Starting
+  this uid was 101, which is a system reserved uid and can cause conflicts with system installed packages. Starting
   with v6, the default uid is 10001. This value needs to be matched between the
   container and the chart, and during this transition period, there is a
   dedicated galaxy-min image that uses the new uid. This image is available at

--- a/galaxy/Chart.yaml
+++ b/galaxy/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: galaxy
 type: application
-version: 5.19.0
-appVersion: "24.1.1"
+version: 6.0.0
+appVersion: "24.2"
 description: Chart for Galaxy, an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -10,7 +10,7 @@ image:
   #- Repository containing the Galaxy image.
   repository: quay.io/galaxyproject/galaxy-min
   #- Galaxy Docker image tag (generally corresponds to the desired Galaxy version)
-  tag: "24.1.1"  # Galaxy versions prior to 24.1.1 contain a bug mapping the extra_files directory
+  tag: "24.2-uid"  # Galaxy versions prior to 24.1.1 contain a bug mapping the extra_files directory
   #-  Galaxy image [pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images)
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This points the default image to a custom-built Galaxy 24.2 release that includes the `galaxy` user system uid change to match #508.