### PR TITLE
For single-node instances disable PDB

### DIFF
--- a/galaxy/templates/hapostgres/pgcluster.yaml
+++ b/galaxy/templates/hapostgres/pgcluster.yaml
@@ -8,6 +8,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   instances: {{ default "1" .Values.postgresql.instances }}
+  {{- if or (not .Values.postgresql.instances) (eq (toString .Values.postgresql.instances) "1") }}
+  enablePDB: false
+  {{- end }}
   bootstrap:
     initdb:
       database: galaxy


### PR DESCRIPTION
CNPG docs recommend disabling the pod disruption budgets when number of instances is set to 1: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#postgresql-clusters-used-for-development-or-testing