### PR TITLE
Apply the Helm tpl function to extraVolumes

### DIFF
--- a/galaxy/templates/deployment-tusd.yaml
+++ b/galaxy/templates/deployment-tusd.yaml
@@ -84,7 +84,7 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- if .Values.extraVolumes }}
-        {{- .Values.extraVolumes | toYaml | nindent 8 }}
+        {{- tpl (.Values.extraVolumes | toYaml | nindent 8) . }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
All of the other deployments apply the `tpl` Helm function to the `extraVolumes` being mounted.

Closes #502 