### PR TITLE
Fix the upgrade process

### DIFF
--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -70,6 +70,7 @@ spec:
             '{{- if .Values.extraInitCommands -}}
              {{- tpl .Values.extraInitCommands $ | nindent 13 }};
              {{- end -}}
+             echo "Cleaning compiled templates cache..."; rm -rf /galaxy/server/database/cache/compiled_templates/*; echo "Template cache cleaned.";
              /galaxy/server/.venv/bin/gunicorn "galaxy.webapps.galaxy.fast_factory:factory()" --timeout {{ .Values.webHandlers.gunicorn.timeout | default 300 }} --pythonpath /galaxy/server/lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080 --workers={{ .Values.webHandlers.gunicorn.workers | default 1 }} --config python:galaxy.web_stack.gunicorn_config --preload {{ .Values.webHandlers.gunicorn.extraArgs | default "" }}']
           {{- if .Values.webHandlers.startupProbe.enabled }}
           startupProbe:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -42,8 +42,10 @@ spec:
         - name: {{ .Chart.Name }}-wait-db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ['sh', '-c', '{{ include "galaxy.init-container-wait-command" . }} sleep {{ .Values.webHandlers.startupDelay }};']
+          args: ['sh', '-c', '{{ include "galaxy.init-container-wait-command" . }} sleep {{ .Values.webHandlers.startupDelay }}; echo "Cleaning cache..."; rm -rf /galaxy/server/database/cache/*; echo "Cache cleaned.";']
           volumeMounts:
+            - name: galaxy-data
+              mountPath: {{ .Values.persistence.mountPath }}
             - name: galaxy-data
               mountPath: /galaxy/server/config/mutable/
               subPath: config
@@ -70,7 +72,6 @@ spec:
             '{{- if .Values.extraInitCommands -}}
              {{- tpl .Values.extraInitCommands $ | nindent 13 }};
              {{- end -}}
-             echo "Cleaning compiled templates cache..."; rm -rf /galaxy/server/database/cache/compiled_templates/*; echo "Template cache cleaned.";
              /galaxy/server/.venv/bin/gunicorn "galaxy.webapps.galaxy.fast_factory:factory()" --timeout {{ .Values.webHandlers.gunicorn.timeout | default 300 }} --pythonpath /galaxy/server/lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080 --workers={{ .Values.webHandlers.gunicorn.workers | default 1 }} --config python:galaxy.web_stack.gunicorn_config --preload {{ .Values.webHandlers.gunicorn.extraArgs | default "" }}']
           {{- if .Values.webHandlers.startupProbe.enabled }}
           startupProbe:

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -32,7 +32,32 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-          command: ['sh', '-c', 'echo [`date`][wait-postgres] - wait-postgres init container starting. Running as `id`.; echo [`date`][wait-postgres] - Chown mount path: {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}; chown {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}; echo [`date`][wait-postgres] - Begin waiting for postgres.; until nc -z -w3 {{ template "galaxy-postgresql.servicename" . }} 5432; do echo [`date`][wait-postgres] - Waiting for galaxy-postgres service...; sleep 2; done; echo [`date`][wait-postgres] - Postgres connection OK. Waiting for database to be fully ready...; sleep 20; echo [`date`][wait-postgres] - Database ready.;']
+          env:
+          {{ include "galaxy.podEnvVars" . }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              echo "[`date`][wait-postgres] - wait-postgres init container starting. Running as `id`."
+              echo "[`date`][wait-postgres] - Chown mount path: {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}"
+              chown {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}
+              echo "[`date`][wait-postgres] - Waiting for database to accept connections..."
+              /galaxy/server/.venv/bin/python3 - <<'PYEOF'
+              import os, sys, time, psycopg2
+              dsn = os.environ['GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION']
+              for _ in range(60):
+                  try:
+                      with psycopg2.connect(dsn, connect_timeout=2) as c:
+                          c.cursor().execute('SELECT 1')
+                      sys.exit(0)
+                  except Exception as e:
+                      print('[`date`][wait-postgres] Waiting for database...', e)
+                      time.sleep(2)
+              print('[`date`][wait-postgres] Timed out waiting for database.')
+              sys.exit(1)
+              PYEOF
+              echo "[`date`][wait-postgres] - Database ready."
           volumeMounts:
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -32,7 +32,7 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-          command: ['sh', '-c', 'echo [`date`][wait-postgres] - wait-postgres init container starting. Running as `id`.; echo [`date`][wait-postgres] - Chown mount path: {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}; chown {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}; echo [`date`][wait-postgres] - Begin waiting for postgres.; until nc -z -w3 {{ template "galaxy-postgresql.servicename" . }} 5432; do echo [`date`][wait-postgres] - Waiting for galaxy-postgres service...; sleep 2; done; echo [`date`][wait-postgres] - Postgres connection OK.;']
+          command: ['sh', '-c', 'echo [`date`][wait-postgres] - wait-postgres init container starting. Running as `id`.; echo [`date`][wait-postgres] - Chown mount path: {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}; chown {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}; echo [`date`][wait-postgres] - Begin waiting for postgres.; until nc -z -w3 {{ template "galaxy-postgresql.servicename" . }} 5432; do echo [`date`][wait-postgres] - Waiting for galaxy-postgres service...; sleep 2; done; echo [`date`][wait-postgres] - Postgres connection OK. Waiting for database to be fully ready...; sleep 20; echo [`date`][wait-postgres] - Database ready.;']
           volumeMounts:
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}


### PR DESCRIPTION
Two issues being addressed:
- On an upgrade, old mako templates may be cached leading to an exception during web handler startup
- With CNPG, for an unclear reason to me, it takes a little while before the database is available. On an upgrade, this causes the db upgrade script to fail. Giving it a bit of time fixes it. Not a great solution but the same flow works for both, a fresh install and an upgrade.