### PR TITLE
Add support for setting resources for each template and update resources

### DIFF
--- a/galaxy/templates/deployment-celery-beat.yaml
+++ b/galaxy/templates/deployment-celery-beat.yaml
@@ -149,7 +149,7 @@ spec:
             {{- tpl (.Values.extraVolumeMounts | toYaml | nindent 12) . }}
             {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.celeryBeat.resources | nindent 12 }}
       volumes:
         - name: galaxy-conf-files
           {{- if .Values.useSecretConfigs }}

--- a/galaxy/templates/deployment-celery.yaml
+++ b/galaxy/templates/deployment-celery.yaml
@@ -149,7 +149,7 @@ spec:
             {{- tpl (.Values.extraVolumeMounts | toYaml | nindent 12) . }}
             {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.celery.resources | nindent 12 }}
       volumes:
         - name: galaxy-conf-files
           {{- if .Values.useSecretConfigs }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -156,7 +156,7 @@ spec:
             {{- tpl ($.Values.extraVolumeMounts | toYaml | nindent 12) $ }}
             {{- end }}
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml $.Values.jobHandlers.resources | nindent 12 }}
       volumes:
         - name: extra-files-probe-script
           configMap:

--- a/galaxy/templates/deployment-tusd.yaml
+++ b/galaxy/templates/deployment-tusd.yaml
@@ -74,7 +74,7 @@ spec:
             {{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.tusd.resources | nindent 12 }}
       volumes:
         - name: galaxy-data
           {{- if .Values.persistence.enabled }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -144,7 +144,7 @@ spec:
             {{- tpl (.Values.extraVolumeMounts | toYaml | nindent 12) . }}
             {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.webHandlers.resources | nindent 12 }}
       volumes:
         - name: galaxy-conf-files
           {{- if .Values.useSecretConfigs }}

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -153,7 +153,7 @@ spec:
             {{- tpl (.Values.extraVolumeMounts | toYaml | nindent 12) . }}
             {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.workflowHandlers.resources | nindent 12 }}
       volumes:
         - name: extra-files-probe-script
           configMap:

--- a/galaxy/templates/hapostgres/pgcluster.yaml
+++ b/galaxy/templates/hapostgres/pgcluster.yaml
@@ -25,6 +25,10 @@ spec:
   {{- if and .Values.postgresql.persistence .Values.postgresql.persistence.extra -}}
   {{- tpl (toYaml .Values.postgresql.persistence.extra) . | nindent 4 }}
   {{- end }}
+  {{- if .Values.postgresql.resources }}
+  resources:
+    {{- toYaml .Values.postgresql.resources | nindent 4 }}
+  {{- end }}
   {{- if and .Values.postgresql.cluster .Values.postgresql.cluster.plugins }}
   plugins:
     {{- toYaml .Values.postgresql.cluster.plugins | nindent 4 }}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -53,6 +53,14 @@ workflowHandlers:
     periodSeconds: 10
     failureThreshold: 30
     timeoutSeconds: 5
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1G
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 7G
+      ephemeral-storage: 10Gi
 
 webHandlers:
   replicaCount: 1
@@ -80,6 +88,14 @@ webHandlers:
     timeout: 300
     workers: 1
     extraArgs: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 2G
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 7G
+      ephemeral-storage: 10Gi
 
 jobHandlers:
   replicaCount: 1
@@ -103,6 +119,14 @@ jobHandlers:
     periodSeconds: 10
     failureThreshold: 30
     timeoutSeconds: 5
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1G
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 7G
+      ephemeral-storage: 10Gi
 
 celery:
   concurrency: 2
@@ -129,6 +153,14 @@ celery:
     periodSeconds: 60
     failureThreshold: 30
     timeoutSeconds: 10
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500M
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 2G
+      ephemeral-storage: 10Gi
 
 celeryBeat:
   logLevel: "INFO"
@@ -154,6 +186,14 @@ celeryBeat:
     periodSeconds: 60
     failureThreshold: 30
     timeoutSeconds: 10
+  resources:
+    requests:
+      cpu: 50m
+      memory: 500M
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 2G
+      ephemeral-storage: 10Gi
 
 metrics:
   #- Enable the metrics server. Defaults to `false`
@@ -374,16 +414,6 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  #- We recommend updating these based on the usage levels of the server.
-  requests:
-    cpu: 100m
-    memory: 1G
-    ephemeral-storage: 1Gi
-  limits:
-    memory: 7G
-    ephemeral-storage: 10Gi
-
 nodeSelector: {}
 
 tolerations: []
@@ -418,6 +448,12 @@ postgresql:
     #  selector:
     #    matchLabels:
     #      label-key: label-value
+  resources:
+   requests:
+     memory: 250M
+     cpu: 200m
+   limits:
+     memory: 2Gi
 
 #- Configuration block for reference data
 refdata:
@@ -797,6 +833,14 @@ tusd:
         paths:
           - path: "/galaxy/api/upload/resumable_upload"
     tls: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500M
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 7G
+      ephemeral-storage: 10Gi
 
 rabbitmq:
   enabled: true
@@ -805,7 +849,13 @@ rabbitmq:
   protocol: amqp
   port: 5672
   nameOverride: rabbitmq
-  extraSpec: {}
+  extraSpec:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 250M
+      limits:
+        memory: 2G
   terminationGracePeriodSeconds: 90
   persistence:
     storageClassName:


### PR DESCRIPTION
There was some imbalance in how resources requests were defined across pods so update those. The updated values are based on usage data I collected from the first 20 minutes of running a cluster (using Galaxy 26.0). During that time, I submitted a workflow so there's some usage of the system included.

CPU usage
<img width="866" height="1211" alt="image" src="https://github.com/user-attachments/assets/b197ae0e-84b6-4c90-8c50-a5c42bfa1efc" />

Memory usage
<img width="868" height="1207" alt="image" src="https://github.com/user-attachments/assets/88ba76e0-335a-4e75-9b7b-6c1685f445eb" />

