### PR TITLE
fix(nginx): add proxy_ssl_server_name on to trainingHook proxy location

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -82,6 +82,7 @@ data:
 {{- if .Values.trainingHook.enabled }}
             location /training-material/ {
                 proxy_pass {{ .Values.trainingHook.url }};
+                proxy_ssl_server_name on;
             }
 {{- end }}
 


### PR DESCRIPTION
## Problem

When `trainingHook.enabled: true`, the nginx `location /training-material/` block proxies to the GTN HTTPS upstream (`training.galaxyproject.org`). Without `proxy_ssl_server_name on`, nginx does not send the SNI header during the TLS handshake, causing a **502 Bad Gateway** for all `/training-material/` requests.

This manifests in the Galaxy UI as **"Click to run unavailable"** on all tool links in embedded GTN tutorials — the GTN loads (if served externally) but cannot communicate back to Galaxy because cross-origin restrictions apply when not proxied through the same origin.

## Fix

Add `proxy_ssl_server_name on;` to the training hook location block so nginx correctly sends SNI when connecting to the HTTPS upstream:

```nginx
location /training-material/ {
    proxy_pass {{ .Values.trainingHook.url }};
    proxy_ssl_server_name on;
}
```

## References

The same fix was applied to the VM-based Galaxy deployment in the infrastructure-playbook:
galaxyproject/infrastructure-playbook@262b572 — *"Set proxy_ssl_server_name for GTN proxy on CloudFlare due to SNI"* (Nate Coraor, 2025-11-20)