### PR TITLE
Fix case of connection-proxy-header annotation

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -879,7 +879,7 @@ tusd:
       nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
       nginx.ingress.kubernetes.io/proxy-buffering: "off"
       nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
-      nginx.ingress.kubernetes.io/connection-proxy-header: "Upgrade"
+      nginx.ingress.kubernetes.io/connection-proxy-header: "upgrade"
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
     hosts:
       - host: ~


### PR DESCRIPTION
The admission webhook validator has become more strict in newer `ingress-nginx` version and rejects `Upgrade` as a value for `nginx.ingress.kubernetes.io/connection-proxy-header`.

Closes #513 