### PR TITLE
Add missing quote 

### DIFF
--- a/galaxy/templates/configmap-post-install.yaml
+++ b/galaxy/templates/configmap-post-install.yaml
@@ -42,7 +42,7 @@ data:
     USER_KEY=$(abm galaxy user key $GALAXY_USER)
     {{- else }}
     # Multi-user Galaxy instance - create user and get their key
-    echo "Multi user instance. User is $GALAXY_USER    
+    echo "Multi user instance. User is $GALAXY_USER"    
     USERNAME=$(echo "$GALAXY_USER" | cut -d'@' -f1)
     USER_KEY=$(abm galaxy user create $USERNAME $GALAXY_USER $GALAXY_MASTER_KEY | jq -r .key)
     {{- end }}


### PR DESCRIPTION
There is a missing quote character that causes `postInstallJob`s to fail on multiuser instances.  