### PR TITLE
Update abm to 2.13.0 for versioned bootstrap configs

### DIFF
--- a/galaxy/templates/job-post-install.yaml
+++ b/galaxy/templates/job-post-install.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "galaxy.serviceAccountName" . }}-trusted
       containers:
       - name: post-install
-        image: {{ .Values.postInstallJob.image | default "quay.io/galaxyproject/abm:2.12.0" }}
+        image: {{ .Values.postInstallJob.image | default "quay.io/galaxyproject/abm:2.13.0" }}
         command: ["/bin/bash", "/tmp/post-install.sh"]
         env:
         - name: GALAXY_URL

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -922,7 +922,7 @@ postInstallJob:
   #- Galaxy user email for imports (job only runs when this is populated)
   galaxyUser: ""
   #- Container image for the post-install job (must include ABM 2.12.0+)
-  image: "quay.io/galaxyproject/abm:2.12.0"
+  image: "quay.io/galaxyproject/abm:2.13.0"
   #- TTL in seconds for job cleanup after completion
   ttlSecondsAfterFinished: 300
   #- Number of retries before marking job as failed


### PR DESCRIPTION
We should do this as well before the 6.8.1 hot fix.