### PR TITLE
Raise fresh-deploy startup timeouts so the post-install job doesn't fail

### DIFF
--- a/galaxy/templates/configmap-post-install.yaml
+++ b/galaxy/templates/configmap-post-install.yaml
@@ -22,7 +22,7 @@ data:
       sleep 10
     done
     for deployment in $(kubectl get deployments -n galaxy | grep galaxy | awk '{print $1}') ; do
-      kubectl rollout status deployment/$deployment -n galaxy --watch --timeout=10m
+      kubectl rollout status deployment/$deployment -n galaxy --watch --timeout={{ .Values.postInstallJob.rolloutTimeout | default "20m" }}
     done
     echo "Galaxy is ready!"
 

--- a/galaxy/templates/deployment-celery-beat.yaml
+++ b/galaxy/templates/deployment-celery-beat.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | default 1800 }}
   replicas: {{ .Values.celeryBeat.replicaCount }}
   selector:
     matchLabels:

--- a/galaxy/templates/deployment-celery.yaml
+++ b/galaxy/templates/deployment-celery.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | default 1800 }}
   replicas: {{ .Values.celery.replicaCount }}
   selector:
     matchLabels:

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  progressDeadlineSeconds: {{ $.Values.progressDeadlineSeconds | default 1800 }}
   replicas: 1
   selector:
     matchLabels:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -10,6 +10,11 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  # Must exceed the startupProbe budget. Galaxy's first boot loads the full toolset and
+  # can take >10m; the Kubernetes default progressDeadlineSeconds of 600s marks the
+  # Deployment ProgressDeadlineExceeded mid-load, which makes `kubectl rollout status`
+  # (used by the post-install job) exit with an error and fail the install.
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | default 1800 }}
   replicas: {{ .Values.webHandlers.replicaCount }}
   selector:
     matchLabels:

--- a/galaxy/templates/deployment-workflow.yaml
+++ b/galaxy/templates/deployment-workflow.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | default 1800 }}
   replicas: {{ .Values.workflowHandlers.replicaCount }}
   selector:
     matchLabels:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -17,6 +17,12 @@ image:
 #- Secrets used to [access a Galaxy image from a private repository](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 imagePullSecrets: []
 
+#- `progressDeadlineSeconds` applied to the Galaxy Deployments (web/job/workflow/celery/
+#- celery-beat). Galaxy's first boot loads the full toolset and can exceed the Kubernetes
+#- default of 600s, which would mark the Deployment `ProgressDeadlineExceeded` mid-load and
+#- fail the post-install `kubectl rollout status`. Keep this above the web startupProbe budget.
+progressDeadlineSeconds: 1800
+
 trainingHook:
   #- Enable the GTN webhook to link references to tools in tutorials to the corresponding tool panel in Galaxy.
   enabled: false
@@ -914,7 +920,7 @@ rabbitmq:
     storageClassName:
     storage:
 
-# PostInstall Job Configuration
+#- PostInstall Job Configuration
 # Enables automatic import of datasets, histories, and workflows after Galaxy deployment
 postInstallJob:
   #- Enable the post-install job to automatically import data and workflows
@@ -925,6 +931,10 @@ postInstallJob:
   image: "quay.io/galaxyproject/abm:2.12.0"
   #- TTL in seconds for job cleanup after completion
   ttlSecondsAfterFinished: 300
+  #- Per-deployment timeout for the `kubectl rollout status` readiness wait. Galaxy's
+  #- first boot loads the full toolset (can take >10m), so keep this generous; it must
+  #- also stay within the Helm post-install hook timeout set by the installer.
+  rolloutTimeout: "20m"
   #- Number of retries before marking job as failed
   backoffLimit: 3
   #- ABM bootstrap configuration in YAML format


### PR DESCRIPTION
## Problem

On a **fresh** single-node install, Galaxy's first boot loads the full toolset and `galaxy-web` can take **>10 minutes** to become Ready. Two chart limits default to ~10 minutes, so the `post-install` hook Job fails with `BackoffLimitExceeded` and aborts the Helm install — even though Galaxy itself comes up fine moments later.

Root cause is a pair of 10-minute gates that don't clear web's slow first load:

1. **`progressDeadlineSeconds` was unset**, so the Galaxy Deployments used the Kubernetes default of **600s**. When web isn't Ready within 10 min the Deployment is flagged `ProgressDeadlineExceeded`, which makes the post-install job's `kubectl rollout status` **exit with an error** — regardless of its `--timeout`. This is inconsistent with the web `startupProbe`, which already allows ~21 min.
2. The post-install **`kubectl rollout status --timeout=10m`** also expires before web is Ready.

## Changes

1. New top-level value **`progressDeadlineSeconds` (default `1800`)**, applied to the `web`, `job`, `workflow`, `celery`, and `celery-beat` Deployments. Keep it above the web `startupProbe` budget.
2. Post-install rollout wait is now configurable via **`postInstallJob.rolloutTimeout` (default `20m`)**.

Both are needed: fixing only one still fails at the other's 10-minute limit.

## Testing

Verified end-to-end on a fresh single-node RKE2 deploy (`galaxy-k8s-boot`): `init-db`, `galaxy-web` (0 restarts), and the `post-install` Job all succeed and the playbook completes cleanly (`failed=0`). Without these changes the same deploy fails the post-install Job at ~10 min.

## Related

Companion to #546 (init-db schema race on fresh installs) and sibling to #545 — all three harden the fresh-deploy path. This PR is independent and can merge on its own.
