### PR TITLE
Trust the ingress controller's X-Forwarded-* headers

### DIFF
--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -77,7 +77,7 @@ spec:
             '{{- if .Values.extraInitCommands -}}
              {{- tpl .Values.extraInitCommands $ | nindent 13 }};
              {{- end -}}
-             /galaxy/server/.venv/bin/gunicorn "galaxy.webapps.galaxy.fast_factory:factory()" --timeout {{ .Values.webHandlers.gunicorn.timeout | default 300 }} --pythonpath /galaxy/server/lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080 --workers={{ .Values.webHandlers.gunicorn.workers | default 1 }} --config python:galaxy.web_stack.gunicorn_config --preload {{ .Values.webHandlers.gunicorn.extraArgs | default "" }}']
+             /galaxy/server/.venv/bin/gunicorn "galaxy.webapps.galaxy.fast_factory:factory()" --timeout {{ .Values.webHandlers.gunicorn.timeout | default 300 }} --pythonpath /galaxy/server/lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080 --workers={{ .Values.webHandlers.gunicorn.workers | default 1 }} --forwarded-allow-ips="{{ .Values.webHandlers.gunicorn.forwardedAllowIps | default "*" }}" --config python:galaxy.web_stack.gunicorn_config --preload {{ .Values.webHandlers.gunicorn.extraArgs | default "" }}']
           {{- if .Values.webHandlers.startupProbe.enabled }}
           startupProbe:
             httpGet:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -93,6 +93,14 @@ webHandlers:
   gunicorn:
     timeout: 300
     workers: 1
+    # Peers whose X-Forwarded-* headers gunicorn will trust. Gunicorn defaults
+    # to 127.0.0.1, which never matches an in-cluster ingress controller, so
+    # X-Forwarded-Proto gets dropped and Galaxy builds absolute URLs (history
+    # export links, activation and notification emails, share links) with
+    # http:// even when the ingress terminates TLS. Narrow this to the ingress
+    # controller's pod CIDR if untrusted workloads can reach the Galaxy service
+    # directly.
+    forwardedAllowIps: "*"
     extraArgs: ""
   resources:
     requests:


### PR DESCRIPTION
# Body
Galaxy deployed with this chart behind a TLS-terminating ingress hands out
`http://` absolute URLs. The most visible symptom is the History Export "to a
link" URL, which is displayed as copy-pasteable text and just doesn't work when
you follow it -- reported by @afgane in
https://github.com/galaxyproject/galaxy/issues/23370. Activation emails, notification
emails, share links, and error reports are all built the same way and are all
wrong on the same instance, they're just slower to get noticed.

The cause isn't in Galaxy. The chart runs gunicorn with `-b 0.0.0.0:8080` and
never sets `--forwarded-allow-ips`, so gunicorn keeps its default of
`127.0.0.1,::1`. In a cluster the peer is the ingress controller's *pod* IP,
which never matches, so uvicorn's ProxyHeadersMiddleware drops
`X-Forwarded-Proto` and the ASGI scope keeps `scheme == "http"`. Galaxy then
builds every qualified URL on that scheme. Relative URLs -- dataset downloads
and the like -- are unaffected, which is why this looks like an export-specific
bug at first glance.

So this adds `webHandlers.gunicorn.forwardedAllowIps`, wired into the gunicorn
command, defaulting to `*`.

On defaulting to `*`: it's worth a look, since it means trusting forwarded
headers from any peer that can reach the pod. My reasoning is that if an
untrusted workload can already reach galaxy-web:8080 directly, it has bypassed
the ingress entirely -- including the mutual TLS that galaxykubeman sets up --
and spoofing `X-Forwarded-For` is strictly weaker than the direct API access it
already has. The real loss is access-log fidelity, which is worth naming but
doesn't seem worth shipping a chart that's silently broken for every TLS
deployment.

I did consider defaulting to the RFC1918 ranges instead, which would be tighter.
I backed off because pod CIDRs aren't always private -- `100.64.0.0/10` shows up
with the AWS VPC CNI and some GKE setups -- and a default that silently fails on
those clusters reintroduces exactly the failure mode this is fixing. The value
takes CIDRs, so anyone who wants to narrow it can:

    webHandlers:
      gunicorn:
        forwardedAllowIps: "10.42.0.0/16"

Happy to flip the default to opt-in (`""`, preserving today's behavior) if you'd
rather this not change out from under existing deployments -- say the word.

Verified the rendered command quotes correctly and that `*` reaches gunicorn
literally rather than glob-expanding against the working directory.

Refs: https://github.com/galaxyproject/galaxy/issues/23370
