### PR TITLE
Let datatype converters resolve their own containers

### DIFF
--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -765,7 +765,17 @@ jobs:
             - id: force_default_container_for_built_in_tools
               if: |
                 from galaxy.tools import GALAXY_LIB_TOOLS_UNVERSIONED
-                tool.id in GALAXY_LIB_TOOLS_UNVERSIONED or "CONVERTER_" == tool.id[:10] or tool.is_datatype_converter
+                # Datatype converters fall into two kinds. Those needing only
+                # what the Galaxy image already ships stay pinned to it: most
+                # run a script from $__tool_directory__, and job pods mount
+                # only /galaxy/server/database, so the Galaxy tree under
+                # /galaxy/server/lib exists solely inside this image. The rest
+                # declare binaries the image does not carry (samtools, htslib,
+                # bedtools, UCSC, openbabel...); leaving them to the container
+                # resolver lets it find their biocontainer.
+                IN_IMAGE = {"python", "bx-python", "galaxy-util", "galaxy_sequence_utils", "coreutils", "bzip2"}
+                is_converter = ("CONVERTER_" == tool.id[:10]) or tool.is_datatype_converter
+                tool.id in GALAXY_LIB_TOOLS_UNVERSIONED or (is_converter and all(r.name in IN_IMAGE for r in tool.requirements.packages))
               params:
                 docker_container_id_override: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         .*data_manager.*:


### PR DESCRIPTION
## Problem

`force_default_container_for_built_in_tools` pins **every** datatype converter to the Galaxy image unconditionally:

```
tool.id in GALAXY_LIB_TOOLS_UNVERSIONED or "CONVERTER_" == tool.id[:10] or tool.is_datatype_converter
```

Converters declare their requirements, so the container resolver would find a biocontainer for them — the override hides it. The Galaxy image carries none of the binaries they ask for. Verified absent from `galaxy-min:26.1-auto`: `samtools`, `bcftools`, `bgzip`, `tabix`, `obabel`, `bedtools`, `bedGraphToBigWig`, `wigToBigWig`, `bigWigToWig`, `bigBedToBed`, `faToTwoBit`, `bowtie-build`, `gmx`, `unzip`, `gawk`, plus Python `pyarrow`, `biom`, `mdtraj`.

Cross-referencing each converter's `<requirements>` against the image: **37 of the 70 shipped converters cannot run.** Symptom is an exit 127, e.g.

```
tool_script.sh: line 9: bgzip: command not found
```

That set includes `bam_to_bai`, so BAM indexing fails — which blocks display and any tool wanting an indexed BAM — along with `fasta_to_fai`, `to_coordinate_sorted_bam`, `cram_to_bam` and the htslib/UCSC/openbabel groups. Implicit conversion is routine, so this is user-facing rather than a test artifact.

## Why not simply drop the override

The override is still needed for the *other* kind of converter. Most run a script from `$__tool_directory__`, and job pods mount only `/galaxy/server/database` — the Galaxy tree under `/galaxy/server/lib` exists solely inside the image. Sending those to a biocontainer loses the script:

```
python: can't open file '/galaxy/server/lib/galaxy/datatypes/converters/bed_to_gff_converter.py'
```

Worth flagging: **"has requirements" is the wrong discriminator** — `python` and `bx-python` are requirements too, and the image already provides them. Keying on that regresses 23 converters that work today. This PR keys on whether the image already satisfies the requirements instead.

## Validation

Deployed to a live k8s cluster and exercised both branches of the rule. 33 converters stay on the Galaxy image, 37 resolve out:

| converter | container |
|---|---|
| `bed_to_gff` (python) | Galaxy image |
| `interval_to_bed` (bx-python) | Galaxy image |
| `csv_to_tabular` (python) | Galaxy image |
| `fasta_to_len` (python) | Galaxy image |
| `sam_to_unsorted_bam` | `biocontainers/samtools:1.17--hd87286a_2` |
| `bam_to_coordinate_sorted_bam` | `biocontainers/samtools:1.17--hd87286a_2` |
| **`bam_to_bai`** | `biocontainers/samtools:1.17--hd87286a_2` |
| `fasta_to_fai` | `biocontainers/samtools:1.17--hd87286a_2` |
| `fasta_to_2bit` | `biocontainers/ucsc-fatotwobit:357--h446ed27_4` |
| `uncompressed_to_gz` | `biocontainers/mulled-v2-468c0df…:d5b6fd31…-0` |

All ten exit 0 and produce correct output. `helm lint` and `helm template` both pass.

Multi-package converters resolve to mulled images, which only exist if that exact hashed combination was ever built — checked each against quay.io, including `uncompressed_to_gz` (htslib 1.16 + bzip2 1.0.8).

Cold image pulls measured **1.0–5.4s** each (`ucsc-fatotwobit` 1.03s, `samtools` 1.67s, `pyarrow` 5.4s), once per image per node under `IfNotPresent`.

## Known limitations

- `parquet_to_csv` stays broken: it needs both `pyarrow` and the Galaxy tree, so no container satisfies it. Equally broken before this change. Adding `pyarrow` to the Galaxy image would fix it and fold it into `IN_IMAGE` naturally.
- `IN_IMAGE` is a hand-maintained allowlist mirroring what the Galaxy image ships. If the image gains or drops one of those packages it needs updating, and a stale entry fails the same way the naive predicate does. A longer-term fix would be for Galaxy to expose "can this container satisfy these requirements" so the list need not be hardcoded.
- The 12 heavy-tail converters (openbabel ×6, gromacs ×2, bowtie ×2, mdtraj, biom-format) resolve under the new rule but were not exercised — no convenient test input. Their images are considerably larger, so their first pull will cost more than the figures above.