### PR TITLE
Link legacy .loc files from reference data into tool_data_path

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -353,23 +353,3 @@ parentRefs:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end -}}
-
-{{/*
-The effective tool_data_path. Galaxy's own config is the source of truth, so
-read it back from configs."galaxy.yml".galaxy.tool_data_path and fall back to
-the chart default when it is unset. That value may itself contain template
-syntax, hence the tpl.
-
-Never reference this helper from tool_data_path itself - it reads that key, so
-doing so would recurse.
-*/}}
-{{- define "galaxy.toolDataPath" -}}
-{{- $cfg := (index (.Values.configs | default dict) "galaxy.yml") | default dict -}}
-{{- $galaxy := (index $cfg "galaxy") | default dict -}}
-{{- $path := index $galaxy "tool_data_path" -}}
-{{- if $path -}}
-{{- tpl (printf "%v" $path) . -}}
-{{- else -}}
-{{- printf "%s/tool-data" .Values.persistence.mountPath -}}
-{{- end -}}
-{{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -353,3 +353,23 @@ parentRefs:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end -}}
+
+{{/*
+The effective tool_data_path. Galaxy's own config is the source of truth, so
+read it back from configs."galaxy.yml".galaxy.tool_data_path and fall back to
+the chart default when it is unset. That value may itself contain template
+syntax, hence the tpl.
+
+Never reference this helper from tool_data_path itself - it reads that key, so
+doing so would recurse.
+*/}}
+{{- define "galaxy.toolDataPath" -}}
+{{- $cfg := (index (.Values.configs | default dict) "galaxy.yml") | default dict -}}
+{{- $galaxy := (index $cfg "galaxy") | default dict -}}
+{{- $path := index $galaxy "tool_data_path" -}}
+{{- if $path -}}
+{{- tpl (printf "%v" $path) . -}}
+{{- else -}}
+{{- printf "%s/tool-data" .Values.persistence.mountPath -}}
+{{- end -}}
+{{- end -}}

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -72,25 +72,38 @@ spec:
               # Best effort on purpose: a missing .loc must not block startup,
               # so this never exits non-zero and never replaces a real file.
               echo "[`date`][init-tool-data] - Linking legacy .loc files into tool_data_path. Running as `id`."
-              TOOL_DATA="{{ .Values.persistence.mountPath }}/tool-data"
+              TOOL_DATA="{{ include "galaxy.toolDataPath" . }}"
               mkdir -p "$TOOL_DATA"
               for f in {{ .Values.refdata.legacyLocFiles | join " " }}; do
-                if [ -e "$TOOL_DATA/$f" ]; then
+                # -e follows the link, so a dangling symlink reads as absent
+                # here but still blocks ln. Test -L separately and replace only
+                # those, leaving real files and working links untouched.
+                if [ -L "$TOOL_DATA/$f" ] && [ ! -e "$TOOL_DATA/$f" ]; then
+                  echo "[`date`][init-tool-data] - $f is a dangling symlink, replacing it."
+                  rm -f "$TOOL_DATA/$f"
+                elif [ -e "$TOOL_DATA/$f" ]; then
                   echo "[`date`][init-tool-data] - $f already present, leaving it as is."
                   continue
                 fi
+                src=""
                 for d in /cvmfs/data.galaxyproject.org/byhand/location /cvmfs/data.galaxyproject.org/managed/location; do
                   if [ -f "$d/$f" ]; then
-                    ln -s "$d/$f" "$TOOL_DATA/$f" && echo "[`date`][init-tool-data] - linked $f -> $d/$f"
+                    src="$d/$f"
                     break
                   fi
                 done
-                [ -e "$TOOL_DATA/$f" ] || echo "[`date`][init-tool-data] - $f not found in reference data, skipping."
+                if [ -z "$src" ]; then
+                  echo "[`date`][init-tool-data] - $f not found in reference data, skipping."
+                elif ln -s "$src" "$TOOL_DATA/$f"; then
+                  echo "[`date`][init-tool-data] - linked $f -> $src"
+                else
+                  echo "[`date`][init-tool-data] - WARNING: found $src but could not link $f."
+                fi
               done
               echo "[`date`][init-tool-data] - init-tool-data container complete."
           volumeMounts:
             - name: galaxy-data
-              mountPath: {{ .Values.persistence.mountPath }}/tool-data
+              mountPath: {{ include "galaxy.toolDataPath" . }}
               subPath: tool-data
             - name: refdata-gxy
               mountPath: /cvmfs/data.galaxyproject.org

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -61,6 +61,45 @@ spec:
           volumeMounts:
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}
+        {{- if and .Values.refdata.enabled .Values.refdata.legacyLocFiles }}
+        - name: {{ .Chart.Name }}-init-tool-data
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              # Best effort on purpose: a missing .loc must not block startup,
+              # so this never exits non-zero and never replaces a real file.
+              echo "[`date`][init-tool-data] - Linking legacy .loc files into tool_data_path. Running as `id`."
+              TOOL_DATA="{{ .Values.persistence.mountPath }}/tool-data"
+              mkdir -p "$TOOL_DATA"
+              for f in {{ .Values.refdata.legacyLocFiles | join " " }}; do
+                if [ -e "$TOOL_DATA/$f" ]; then
+                  echo "[`date`][init-tool-data] - $f already present, leaving it as is."
+                  continue
+                fi
+                for d in /cvmfs/data.galaxyproject.org/byhand/location /cvmfs/data.galaxyproject.org/managed/location; do
+                  if [ -f "$d/$f" ]; then
+                    ln -s "$d/$f" "$TOOL_DATA/$f" && echo "[`date`][init-tool-data] - linked $f -> $d/$f"
+                    break
+                  fi
+                done
+                [ -e "$TOOL_DATA/$f" ] || echo "[`date`][init-tool-data] - $f not found in reference data, skipping."
+              done
+              echo "[`date`][init-tool-data] - init-tool-data container complete."
+          volumeMounts:
+            - name: galaxy-data
+              mountPath: {{ .Values.persistence.mountPath }}/tool-data
+              subPath: tool-data
+            - name: refdata-gxy
+              mountPath: /cvmfs/data.galaxyproject.org
+              {{- if eq .Values.refdata.type "cvmfs" }}
+              subPath: data.galaxyproject.org
+              # CVMFS automount volumes must be mounted with HostToContainer mount propagation.
+              mountPropagation: HostToContainer
+              {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-init-db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -72,7 +72,7 @@ spec:
               # Best effort on purpose: a missing .loc must not block startup,
               # so this never exits non-zero and never replaces a real file.
               echo "[`date`][init-tool-data] - Linking legacy .loc files into tool_data_path. Running as `id`."
-              TOOL_DATA="{{ include "galaxy.toolDataPath" . }}"
+              TOOL_DATA="{{ .Values.persistence.mountPath }}/tool-data"
               mkdir -p "$TOOL_DATA"
               for f in {{ .Values.refdata.legacyLocFiles | join " " }}; do
                 # -e follows the link, so a dangling symlink reads as absent
@@ -103,7 +103,7 @@ spec:
               echo "[`date`][init-tool-data] - init-tool-data container complete."
           volumeMounts:
             - name: galaxy-data
-              mountPath: {{ include "galaxy.toolDataPath" . }}
+              mountPath: {{ .Values.persistence.mountPath }}/tool-data
               subPath: tool-data
             - name: refdata-gxy
               mountPath: /cvmfs/data.galaxyproject.org

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -535,9 +535,15 @@ refdata:
   #- `-g '${GALAXY_DATA_INDEX_DIR}'` and open `<tool_data_path>/<name>.loc`
   #- directly, so pointing `tool_data_table_config_path` at the reference data
   #- does not reach them and they fail with FileNotFoundError. The setup job
-  #- symlinks each of these from the reference data into `tool_data_path`
-  #- when it finds them; missing ones are skipped, and an existing real file
-  #- is never replaced. Set to [] to disable.
+  #- symlinks each of these from the reference data into the chart's tool-data
+  #- directory when it finds them; missing ones are skipped, and an existing
+  #- real file is never replaced. Set to [] to disable.
+  #-
+  #- Like the rest of the chart, this assumes tool_data_path is left at its
+  #- default of `{persistence.mountPath}/tool-data`. Overriding
+  #- `configs."galaxy.yml".galaxy.tool_data_path` is not supported: the
+  #- long-running Galaxy pods mount only the whole PVC at
+  #- `persistence.mountPath`, so a custom path would not exist inside them.
   legacyLocFiles:
     - alignseq.loc       #- Extract Genomic DNA, BLAT
     - twobit.loc         #- Extract Genomic DNA, BLAT (fallback for alignseq)
@@ -589,7 +595,7 @@ configs:
         k8s_persistent_volume_claims: |-
           {{ template "galaxy.pvcname" . -}}/config:{{ .Values.persistence.mountPath -}}/config:r,
           {{- template "galaxy.pvcname" . -}}/tmp:{{ .Values.persistence.mountPath -}}/tmp:rw,
-          {{- template "galaxy.pvcname" . -}}/tool-data:{{ include "galaxy.toolDataPath" . -}}:rw,
+          {{- template "galaxy.pvcname" . -}}/tool-data:{{ .Values.persistence.mountPath -}}/tool-data:rw,
           {{- template "galaxy.pvcname" . -}}/tools:{{ .Values.persistence.mountPath -}}/tools:r,
           {{- template "galaxy.pvcname" . -}}/shed_tools:{{ .Values.persistence.mountPath -}}/shed_tools:r
           {{- if .Values.refdata.enabled -}}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -589,7 +589,7 @@ configs:
         k8s_persistent_volume_claims: |-
           {{ template "galaxy.pvcname" . -}}/config:{{ .Values.persistence.mountPath -}}/config:r,
           {{- template "galaxy.pvcname" . -}}/tmp:{{ .Values.persistence.mountPath -}}/tmp:rw,
-          {{- template "galaxy.pvcname" . -}}/tool-data:{{ .Values.persistence.mountPath -}}/tool-data:rw,
+          {{- template "galaxy.pvcname" . -}}/tool-data:{{ include "galaxy.toolDataPath" . -}}:rw,
           {{- template "galaxy.pvcname" . -}}/tools:{{ .Values.persistence.mountPath -}}/tools:r,
           {{- template "galaxy.pvcname" . -}}/shed_tools:{{ .Values.persistence.mountPath -}}/shed_tools:r
           {{- if .Values.refdata.enabled -}}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -531,6 +531,21 @@ refdata:
   type: cvmfs
   pvc:
     size: 10Gi
+  #- A handful of legacy Galaxy tools do not go through data tables. They take
+  #- `-g '${GALAXY_DATA_INDEX_DIR}'` and open `<tool_data_path>/<name>.loc`
+  #- directly, so pointing `tool_data_table_config_path` at the reference data
+  #- does not reach them and they fail with FileNotFoundError. The setup job
+  #- symlinks each of these from the reference data into `tool_data_path`
+  #- when it finds them; missing ones are skipped, and an existing real file
+  #- is never replaced. Set to [] to disable.
+  legacyLocFiles:
+    - alignseq.loc       #- Extract Genomic DNA, BLAT
+    - twobit.loc         #- Extract Genomic DNA, BLAT (fallback for alignseq)
+    - maf_index.loc      #- Interval2Maf, MAF stats, GeneBed/Interval MAF to FASTA
+    - maf_pairwise.loc   #- Interval2Maf pairwise
+    - microbial_data.loc #- Microbial data import
+    - sift_db.loc        #- SIFT
+    - srma_index.loc     #- SRMA
 
 #- Configuration block if `cvmfs` is used as `refdata.type`
 cvmfs:


### PR DESCRIPTION
## Problem

A handful of legacy Galaxy tools never go through data tables. They take `-g '${GALAXY_DATA_INDEX_DIR}'` and open `<tool_data_path>/<name>.loc` **by path** — `GALAXY_DATA_INDEX_DIR` being `tool_data_path` (`lib/galaxy/tools/evaluation.py:650`).

The chart already wires `tool_data_table_config_path` at the reference data, so table-driven tools are fine. But that never reaches these tools, and `tool_data_path` holds only `.loc.sample` files on a fresh deployment. So they fail outright:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/galaxy/server/database/tool-data/alignseq.loc'
```

| tool | needs |
|---|---|
| Extract Genomic DNA, BLAT | `alignseq.loc`, `twobit.loc` |
| Interval2Maf, MAF stats, GeneBed/Interval MAF to FASTA | `maf_index.loc` |
| Interval2Maf pairwise | `maf_pairwise.loc` |
| Microbial data import | `microbial_data.loc` |
| SIFT | `sift_db.loc` |
| SRMA | `srma_index.loc` |

All seven ship in the reference data under `byhand/location`.

## Change

`templates/jobs-init.yaml` already mounts the Galaxy PVC and the reference data in the same pod, so this adds an init container that symlinks each file into `tool_data_path` when `refdata.enabled`.

Symlinks rather than copies: the files stay in step with the reference data and `microbial_data.loc` alone is 10k lines.

Deliberately **best effort** — it never exits non-zero, skips files the reference data does not carry, and never replaces an existing real file. A missing or operator-supplied `.loc` cannot block startup.

The list is exposed as `refdata.legacyLocFiles`; set it to `[]` to disable. Not repointing `tool_data_path` at the reference data, since it must stay writable for shed tools and data managers.

## Validation

`helm lint` and `helm template` pass. Gating verified: absent with `refdata.enabled=false`, absent with `legacyLocFiles` empty, and the CVMFS-only `subPath`/`mountPropagation` correctly omitted for `refdata.type=s3csi`.

Ran the **rendered** script on a live k8s deployment with CVMFS reference data:

- all seven linked, running as the `galaxy` user
- second run reports all seven already present (idempotent)
- replacing one with a real file leaves it untouched, content preserved
- an unknown filename is skipped, exit 0

Then `Extract Genomic DNA` on an hg38 BED, `index_source=cached` — the exact path that previously raised `FileNotFoundError`:

```
state: ok   exit: 0   output: fasta, 188 bytes

>hg38_chr1_1000000_1000060_+ f1
GTGGAGCGCGCCGCCACGGACCAcgggcgggctggcgggcgagcggcgag
cgcgcggCGA
>hg38_chr1_2000000_2000060_- f2
tcctgaggagctgggactccaggcgcctgcaccacacctggctaattttt
tgtattttta
```

Correct coordinates, soft-masking preserved, minus-strand feature reverse-complemented.

## Coverage of the referenced data

Sampled paths out of each file against the public repository. `alignseq.loc` (859 `seq` entries, hg38/hg19/hg18/mm10/mm9/sacCer3 all present), `maf_index.loc`, `maf_pairwise.loc`, `microbial_data.loc`, `sift_db.loc` and `srma_index.loc` all resolve fully.

`twobit.loc` is only partly backed — 8 of 26 sampled. It is consulted solely as a fallback when `alignseq.loc` has no entry for a genome, so linking it can only add working genomes; omitting it would strictly remove them.

## Note

This fixes the `index_source=cached` branch of Extract Genomic DNA. Its `history` branch builds a 2bit via `faToTwoBit`, which the Galaxy image does not carry, and the tool sits on `GALAXY_LIB_TOOLS_VERSIONED` below the threshold so container resolvers are skipped for it — that branch needs Galaxy's Python environment *and* an external binary, so no container choice satisfies it. Out of scope here.