### PR TITLE
Release: datatype converter container resolution and legacy .loc linking

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -353,23 +353,3 @@ parentRefs:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end -}}
-
-{{/*
-The effective tool_data_path. Galaxy's own config is the source of truth, so
-read it back from configs."galaxy.yml".galaxy.tool_data_path and fall back to
-the chart default when it is unset. That value may itself contain template
-syntax, hence the tpl.
-
-Never reference this helper from tool_data_path itself - it reads that key, so
-doing so would recurse.
-*/}}
-{{- define "galaxy.toolDataPath" -}}
-{{- $cfg := (index (.Values.configs | default dict) "galaxy.yml") | default dict -}}
-{{- $galaxy := (index $cfg "galaxy") | default dict -}}
-{{- $path := index $galaxy "tool_data_path" -}}
-{{- if $path -}}
-{{- tpl (printf "%v" $path) . -}}
-{{- else -}}
-{{- printf "%s/tool-data" .Values.persistence.mountPath -}}
-{{- end -}}
-{{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -353,3 +353,23 @@ parentRefs:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end -}}
+
+{{/*
+The effective tool_data_path. Galaxy's own config is the source of truth, so
+read it back from configs."galaxy.yml".galaxy.tool_data_path and fall back to
+the chart default when it is unset. That value may itself contain template
+syntax, hence the tpl.
+
+Never reference this helper from tool_data_path itself - it reads that key, so
+doing so would recurse.
+*/}}
+{{- define "galaxy.toolDataPath" -}}
+{{- $cfg := (index (.Values.configs | default dict) "galaxy.yml") | default dict -}}
+{{- $galaxy := (index $cfg "galaxy") | default dict -}}
+{{- $path := index $galaxy "tool_data_path" -}}
+{{- if $path -}}
+{{- tpl (printf "%v" $path) . -}}
+{{- else -}}
+{{- printf "%s/tool-data" .Values.persistence.mountPath -}}
+{{- end -}}
+{{- end -}}

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -72,25 +72,38 @@ spec:
               # Best effort on purpose: a missing .loc must not block startup,
               # so this never exits non-zero and never replaces a real file.
               echo "[`date`][init-tool-data] - Linking legacy .loc files into tool_data_path. Running as `id`."
-              TOOL_DATA="{{ .Values.persistence.mountPath }}/tool-data"
+              TOOL_DATA="{{ include "galaxy.toolDataPath" . }}"
               mkdir -p "$TOOL_DATA"
               for f in {{ .Values.refdata.legacyLocFiles | join " " }}; do
-                if [ -e "$TOOL_DATA/$f" ]; then
+                # -e follows the link, so a dangling symlink reads as absent
+                # here but still blocks ln. Test -L separately and replace only
+                # those, leaving real files and working links untouched.
+                if [ -L "$TOOL_DATA/$f" ] && [ ! -e "$TOOL_DATA/$f" ]; then
+                  echo "[`date`][init-tool-data] - $f is a dangling symlink, replacing it."
+                  rm -f "$TOOL_DATA/$f"
+                elif [ -e "$TOOL_DATA/$f" ]; then
                   echo "[`date`][init-tool-data] - $f already present, leaving it as is."
                   continue
                 fi
+                src=""
                 for d in /cvmfs/data.galaxyproject.org/byhand/location /cvmfs/data.galaxyproject.org/managed/location; do
                   if [ -f "$d/$f" ]; then
-                    ln -s "$d/$f" "$TOOL_DATA/$f" && echo "[`date`][init-tool-data] - linked $f -> $d/$f"
+                    src="$d/$f"
                     break
                   fi
                 done
-                [ -e "$TOOL_DATA/$f" ] || echo "[`date`][init-tool-data] - $f not found in reference data, skipping."
+                if [ -z "$src" ]; then
+                  echo "[`date`][init-tool-data] - $f not found in reference data, skipping."
+                elif ln -s "$src" "$TOOL_DATA/$f"; then
+                  echo "[`date`][init-tool-data] - linked $f -> $src"
+                else
+                  echo "[`date`][init-tool-data] - WARNING: found $src but could not link $f."
+                fi
               done
               echo "[`date`][init-tool-data] - init-tool-data container complete."
           volumeMounts:
             - name: galaxy-data
-              mountPath: {{ .Values.persistence.mountPath }}/tool-data
+              mountPath: {{ include "galaxy.toolDataPath" . }}
               subPath: tool-data
             - name: refdata-gxy
               mountPath: /cvmfs/data.galaxyproject.org

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -61,6 +61,45 @@ spec:
           volumeMounts:
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}
+        {{- if and .Values.refdata.enabled .Values.refdata.legacyLocFiles }}
+        - name: {{ .Chart.Name }}-init-tool-data
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              # Best effort on purpose: a missing .loc must not block startup,
+              # so this never exits non-zero and never replaces a real file.
+              echo "[`date`][init-tool-data] - Linking legacy .loc files into tool_data_path. Running as `id`."
+              TOOL_DATA="{{ .Values.persistence.mountPath }}/tool-data"
+              mkdir -p "$TOOL_DATA"
+              for f in {{ .Values.refdata.legacyLocFiles | join " " }}; do
+                if [ -e "$TOOL_DATA/$f" ]; then
+                  echo "[`date`][init-tool-data] - $f already present, leaving it as is."
+                  continue
+                fi
+                for d in /cvmfs/data.galaxyproject.org/byhand/location /cvmfs/data.galaxyproject.org/managed/location; do
+                  if [ -f "$d/$f" ]; then
+                    ln -s "$d/$f" "$TOOL_DATA/$f" && echo "[`date`][init-tool-data] - linked $f -> $d/$f"
+                    break
+                  fi
+                done
+                [ -e "$TOOL_DATA/$f" ] || echo "[`date`][init-tool-data] - $f not found in reference data, skipping."
+              done
+              echo "[`date`][init-tool-data] - init-tool-data container complete."
+          volumeMounts:
+            - name: galaxy-data
+              mountPath: {{ .Values.persistence.mountPath }}/tool-data
+              subPath: tool-data
+            - name: refdata-gxy
+              mountPath: /cvmfs/data.galaxyproject.org
+              {{- if eq .Values.refdata.type "cvmfs" }}
+              subPath: data.galaxyproject.org
+              # CVMFS automount volumes must be mounted with HostToContainer mount propagation.
+              mountPropagation: HostToContainer
+              {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-init-db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/galaxy/templates/jobs-init.yaml
+++ b/galaxy/templates/jobs-init.yaml
@@ -72,7 +72,7 @@ spec:
               # Best effort on purpose: a missing .loc must not block startup,
               # so this never exits non-zero and never replaces a real file.
               echo "[`date`][init-tool-data] - Linking legacy .loc files into tool_data_path. Running as `id`."
-              TOOL_DATA="{{ include "galaxy.toolDataPath" . }}"
+              TOOL_DATA="{{ .Values.persistence.mountPath }}/tool-data"
               mkdir -p "$TOOL_DATA"
               for f in {{ .Values.refdata.legacyLocFiles | join " " }}; do
                 # -e follows the link, so a dangling symlink reads as absent
@@ -103,7 +103,7 @@ spec:
               echo "[`date`][init-tool-data] - init-tool-data container complete."
           volumeMounts:
             - name: galaxy-data
-              mountPath: {{ include "galaxy.toolDataPath" . }}
+              mountPath: {{ .Values.persistence.mountPath }}/tool-data
               subPath: tool-data
             - name: refdata-gxy
               mountPath: /cvmfs/data.galaxyproject.org

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -535,9 +535,15 @@ refdata:
   #- `-g '${GALAXY_DATA_INDEX_DIR}'` and open `<tool_data_path>/<name>.loc`
   #- directly, so pointing `tool_data_table_config_path` at the reference data
   #- does not reach them and they fail with FileNotFoundError. The setup job
-  #- symlinks each of these from the reference data into `tool_data_path`
-  #- when it finds them; missing ones are skipped, and an existing real file
-  #- is never replaced. Set to [] to disable.
+  #- symlinks each of these from the reference data into the chart's tool-data
+  #- directory when it finds them; missing ones are skipped, and an existing
+  #- real file is never replaced. Set to [] to disable.
+  #-
+  #- Like the rest of the chart, this assumes tool_data_path is left at its
+  #- default of `{persistence.mountPath}/tool-data`. Overriding
+  #- `configs."galaxy.yml".galaxy.tool_data_path` is not supported: the
+  #- long-running Galaxy pods mount only the whole PVC at
+  #- `persistence.mountPath`, so a custom path would not exist inside them.
   legacyLocFiles:
     - alignseq.loc       #- Extract Genomic DNA, BLAT
     - twobit.loc         #- Extract Genomic DNA, BLAT (fallback for alignseq)
@@ -589,7 +595,7 @@ configs:
         k8s_persistent_volume_claims: |-
           {{ template "galaxy.pvcname" . -}}/config:{{ .Values.persistence.mountPath -}}/config:r,
           {{- template "galaxy.pvcname" . -}}/tmp:{{ .Values.persistence.mountPath -}}/tmp:rw,
-          {{- template "galaxy.pvcname" . -}}/tool-data:{{ include "galaxy.toolDataPath" . -}}:rw,
+          {{- template "galaxy.pvcname" . -}}/tool-data:{{ .Values.persistence.mountPath -}}/tool-data:rw,
           {{- template "galaxy.pvcname" . -}}/tools:{{ .Values.persistence.mountPath -}}/tools:r,
           {{- template "galaxy.pvcname" . -}}/shed_tools:{{ .Values.persistence.mountPath -}}/shed_tools:r
           {{- if .Values.refdata.enabled -}}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -589,7 +589,7 @@ configs:
         k8s_persistent_volume_claims: |-
           {{ template "galaxy.pvcname" . -}}/config:{{ .Values.persistence.mountPath -}}/config:r,
           {{- template "galaxy.pvcname" . -}}/tmp:{{ .Values.persistence.mountPath -}}/tmp:rw,
-          {{- template "galaxy.pvcname" . -}}/tool-data:{{ .Values.persistence.mountPath -}}/tool-data:rw,
+          {{- template "galaxy.pvcname" . -}}/tool-data:{{ include "galaxy.toolDataPath" . -}}:rw,
           {{- template "galaxy.pvcname" . -}}/tools:{{ .Values.persistence.mountPath -}}/tools:r,
           {{- template "galaxy.pvcname" . -}}/shed_tools:{{ .Values.persistence.mountPath -}}/shed_tools:r
           {{- if .Values.refdata.enabled -}}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -531,6 +531,21 @@ refdata:
   type: cvmfs
   pvc:
     size: 10Gi
+  #- A handful of legacy Galaxy tools do not go through data tables. They take
+  #- `-g '${GALAXY_DATA_INDEX_DIR}'` and open `<tool_data_path>/<name>.loc`
+  #- directly, so pointing `tool_data_table_config_path` at the reference data
+  #- does not reach them and they fail with FileNotFoundError. The setup job
+  #- symlinks each of these from the reference data into `tool_data_path`
+  #- when it finds them; missing ones are skipped, and an existing real file
+  #- is never replaced. Set to [] to disable.
+  legacyLocFiles:
+    - alignseq.loc       #- Extract Genomic DNA, BLAT
+    - twobit.loc         #- Extract Genomic DNA, BLAT (fallback for alignseq)
+    - maf_index.loc      #- Interval2Maf, MAF stats, GeneBed/Interval MAF to FASTA
+    - maf_pairwise.loc   #- Interval2Maf pairwise
+    - microbial_data.loc #- Microbial data import
+    - sift_db.loc        #- SIFT
+    - srma_index.loc     #- SRMA
 
 #- Configuration block if `cvmfs` is used as `refdata.type`
 cvmfs:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -765,7 +765,17 @@ jobs:
             - id: force_default_container_for_built_in_tools
               if: |
                 from galaxy.tools import GALAXY_LIB_TOOLS_UNVERSIONED
-                tool.id in GALAXY_LIB_TOOLS_UNVERSIONED or "CONVERTER_" == tool.id[:10] or tool.is_datatype_converter
+                # Datatype converters fall into two kinds. Those needing only
+                # what the Galaxy image already ships stay pinned to it: most
+                # run a script from $__tool_directory__, and job pods mount
+                # only /galaxy/server/database, so the Galaxy tree under
+                # /galaxy/server/lib exists solely inside this image. The rest
+                # declare binaries the image does not carry (samtools, htslib,
+                # bedtools, UCSC, openbabel...); leaving them to the container
+                # resolver lets it find their biocontainer.
+                IN_IMAGE = {"python", "bx-python", "galaxy-util", "galaxy_sequence_utils", "coreutils", "bzip2"}
+                is_converter = ("CONVERTER_" == tool.id[:10]) or tool.is_datatype_converter
+                tool.id in GALAXY_LIB_TOOLS_UNVERSIONED or (is_converter and all(r.name in IN_IMAGE for r in tool.requirements.packages))
               params:
                 docker_container_id_override: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         .*data_manager.*:


### PR DESCRIPTION
Merges `dev` into `master`.

**#555 — Let datatype converters resolve their own containers.** `force_default_container_for_built_in_tools` pinned every datatype converter to the Galaxy image, which carries none of the binaries they declare, so 37 of 70 converters could not run — `bam_to_bai` among them, breaking BAM indexing. Converters whose requirements the image already satisfies stay pinned (many run a script from `$__tool_directory__`, which exists only inside the image); the rest now resolve to their biocontainer.

**#556 — Link legacy `.loc` files from reference data into `tool_data_path`.** A few legacy tools bypass data tables and open `<tool_data_path>/<name>.loc` by path, so they failed with `FileNotFoundError` on a fresh deployment. The setup job now symlinks them from the reference data when `refdata.enabled`. Best effort: never exits non-zero, skips files the reference data lacks, replaces only dangling links, and never overwrites a real file. Configurable via `refdata.legacyLocFiles`.

Both were validated on a live cluster with CVMFS reference data.

Note: `Chart.yaml` is at 6.8.3 on both branches — a release bump is not included here.