### PR TITLE
Work around doubled URL prefix in Galaxy post-login redirect (#551)

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -79,6 +79,16 @@ data:
                 add_header X-Frame-Options SAMEORIGIN;
                 add_header X-Content-Type-Options nosniff;
             }
+{{- with trimSuffix "/" .Values.ingress.path }}
+
+            # Galaxy releases without the fix from galaxyproject/galaxy#23274
+            # double the URL prefix in the post-login redirect ({{ . }}{{ . }}/...).
+            # Collapse the duplicated prefix until that fix ships in a tagged release.
+            location {{ . }}{{ . }}/ {
+                absolute_redirect off;
+                rewrite ^{{ . }}(.*)$ $1 redirect;
+            }
+{{- end }}
 {{- if .Values.trainingHook.enabled }}
             location /training-material/ {
                 proxy_pass {{ .Values.trainingHook.url }};


### PR DESCRIPTION
On deployments served under a URL prefix (the default `/galaxy`), logging in bounces the user to `/galaxy/galaxy/`, which returns a 404. This is a Galaxy application bug: the server builds the login page's `redirect` parameter from `request.path`, which includes the URL prefix, and the client then prepends the prefix again when following it after authentication. The bug is fixed upstream in galaxyproject/galaxy#23274 (merged to `release_26.1` on 2026-08-11), but that fix is not yet in any tagged Galaxy release — 26.0.x, 26.1.0, and 26.1.1 are all affected.

Until a Galaxy release ships with the fix, this PR adds a small workaround to the internal nginx configuration: a `location` block matching the duplicated prefix (e.g. `/galaxy/galaxy/`) that issues a relative 302 collapsing it back to a single prefix, preserving the rest of the path. The block is only rendered when `ingress.path` is a non-root prefix, and it is harmless once the upstream fix ships, since the duplicated prefix is never a valid Galaxy route. The `:7080` trailing-slash redirect also reported in this issue is fixed separately by the PR for #558.

Closes #551
