### PR TITLE
Disable absolute_redirect in internal nginx (#558)

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -38,6 +38,7 @@ data:
         server {
             listen {{ .Values.nginx.containerPort }};
             server_name galaxy;
+            absolute_redirect off;
 
             location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}static {
                 alias {{ .Values.nginx.galaxyStaticDir }};


### PR DESCRIPTION
On TLS-terminated deployments, requesting the Galaxy prefix without a trailing slash (e.g. `https://host/galaxy`) returned a 301 redirect to `http://host:7080/galaxy/`. The redirect is generated by the chart's internal nginx, which builds automatic trailing-slash redirects as absolute URLs using its own listen scheme and port (`absolute_redirect on` is the nginx default). The resulting URL leaks the internal container port and is unreachable from outside the cluster. This is complementary to the gunicorn `--forwarded-allow-ips` fix from #552, which only corrected URLs generated by Galaxy itself; this redirect is answered by nginx directly and never reaches Galaxy.

This change adds `absolute_redirect off;` to the server block in `templates/configmap-nginx.yaml`, so nginx emits a relative `Location: /galaxy/` header that is scheme- and host-agnostic and works behind any ingress or Gateway implementation. The fix was verified on a live 6.8.4 deployment (RKE2 with ingress-nginx TLS termination), where the same request now returns `location: /galaxy/` and follows through to a 200 response.

Closes #558
