### PR TITLE
Add nginx.conf.forwardedProtoOverride to pin X-Forwarded-Proto

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -1,3 +1,14 @@
+{{- /*
+The override is interpolated straight into an nginx `map` directive, so an
+unusable value (a stray semicolon, an extra word) renders a config nginx cannot
+parse and galaxy-nginx crash-loops with the reason buried in pod logs. Reject it
+here instead, while the operator is still looking at a helm command.
+*/ -}}
+{{- with .Values.nginx.conf.forwardedProtoOverride }}
+{{- if not (has . (list "http" "https")) }}
+{{- fail (printf "nginx.conf.forwardedProtoOverride must be \"http\" or \"https\", got %q" .) }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -31,8 +31,8 @@ data:
         client_max_body_size {{ .Values.nginx.conf.client_max_body_size }};
 
         map $http_x_forwarded_proto $proxy_x_forwarded_proto {
-          default $http_x_forwarded_proto;
-          '' $scheme;
+          default {{ .Values.nginx.conf.forwardedProtoOverride | default "$http_x_forwarded_proto" }};
+          '' {{ .Values.nginx.conf.forwardedProtoOverride | default "$scheme" }};
         }
 
         server {

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -896,6 +896,14 @@ nginx:
   containerPort: 7080
   conf:
     client_max_body_size: 100g
+    #- Value to pin the `X-Forwarded-Proto` header sent to Galaxy, overriding
+    #- whatever arrives from upstream. Set to `https` when TLS terminates at a
+    #- proxy outside the cluster that speaks plain HTTP inward without setting
+    #- the header (e.g. Terra/Leonardo): otherwise Galaxy sees `scheme == http`
+    #- and builds qualified URLs (history export links, share links, emails)
+    #- with `http://` and issues session cookies without the Secure flag.
+    #- Leave empty to pass the upstream header through unchanged (default).
+    forwardedProtoOverride: ""
   resources:
     # We recommend updating these based on the usage levels of the server
     requests:


### PR DESCRIPTION
#552 makes gunicorn trust `X-Forwarded-Proto`, which fixes the `http://` qualified-URL bug if the header carries the right value. But on topologies where TLS terminates at a proxy *outside* the cluster (e.g. Terra/Leonardo) gunicorn now faithfully trusts an incorrect header. Galaxy still sees `scheme == http` and builds history-export/share/email links with `http://`, and issues session cookies without the `Secure` flag (galaxyproject/galaxy#23370).

The chart's galaxy-nginx map (`map $http_x_forwarded_proto $proxy_x_forwarded_proto`) is the natural place to correct the header, but it is hardcoded in `configmap-nginx.yaml`. This PR adds `nginx.conf.forwardedProtoOverride` (default `""`) to make that a values-level setting: empty preserves the existing behavior while `https` pins the header value.

Once this is merged we can undo galaxyproject/galaxy-k8s-boot#117

🤖 Generated with [Claude Code](https://claude.com/claude-code) and reviewed by a human.
