### PR TITLE
Release: forwarded-proto handling for TLS-terminating proxies

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -1,3 +1,14 @@
+{{- /*
+The override is interpolated straight into an nginx `map` directive, so an
+unusable value (a stray semicolon, an extra word) renders a config nginx cannot
+parse and galaxy-nginx crash-loops with the reason buried in pod logs. Reject it
+here instead, while the operator is still looking at a helm command.
+*/ -}}
+{{- with .Values.nginx.conf.forwardedProtoOverride }}
+{{- if not (has . (list "http" "https")) }}
+{{- fail (printf "nginx.conf.forwardedProtoOverride must be \"http\" or \"https\", got %q" .) }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -31,8 +31,8 @@ data:
         client_max_body_size {{ .Values.nginx.conf.client_max_body_size }};
 
         map $http_x_forwarded_proto $proxy_x_forwarded_proto {
-          default $http_x_forwarded_proto;
-          '' $scheme;
+          default {{ .Values.nginx.conf.forwardedProtoOverride | default "$http_x_forwarded_proto" }};
+          '' {{ .Values.nginx.conf.forwardedProtoOverride | default "$scheme" }};
         }
 
         server {

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -896,6 +896,14 @@ nginx:
   containerPort: 7080
   conf:
     client_max_body_size: 100g
+    #- Value to pin the `X-Forwarded-Proto` header sent to Galaxy, overriding
+    #- whatever arrives from upstream. Set to `https` when TLS terminates at a
+    #- proxy outside the cluster that speaks plain HTTP inward without setting
+    #- the header (e.g. Terra/Leonardo): otherwise Galaxy sees `scheme == http`
+    #- and builds qualified URLs (history export links, share links, emails)
+    #- with `http://` and issues session cookies without the Secure flag.
+    #- Leave empty to pass the upstream header through unchanged (default).
+    forwardedProtoOverride: ""
   resources:
     # We recommend updating these based on the usage levels of the server
     requests:


### PR DESCRIPTION
Merges `dev` into `master`.

**#552 — Trust the ingress controller's `X-Forwarded-*` headers.** Gunicorn's
default `forwarded_allow_ips` (`127.0.0.1,::1`) never matches an in-cluster
ingress controller's pod IP, so uvicorn dropped `X-Forwarded-Proto` and Galaxy
built qualified URLs (history export links, activation/notification emails,
share links, error reports) on `http://` even behind a TLS-terminating
ingress (galaxyproject/galaxy#23370). Adds
`webHandlers.gunicorn.forwardedAllowIps`, defaulting to `*`.

**#561 — Add `nginx.conf.forwardedProtoOverride`.** #552 alone still leaves
topologies where TLS terminates *outside* the cluster (e.g. Terra/Leonardo)
sending an incorrect `X-Forwarded-Proto` that gunicorn now faithfully trusts.
This adds a values-level override (default `""`, preserving existing
behavior) to pin the header to `https` in the galaxy-nginx map.

Both were merged individually; this bundles them for release.