### PR TITLE
Release 6.8.6

### DIFF
--- a/galaxy/templates/configmap-nginx.yaml
+++ b/galaxy/templates/configmap-nginx.yaml
@@ -38,6 +38,7 @@ data:
         server {
             listen {{ .Values.nginx.containerPort }};
             server_name galaxy;
+            absolute_redirect off;
 
             location {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}static {
                 alias {{ .Values.nginx.galaxyStaticDir }};


### PR DESCRIPTION
## Summary
Patch release capturing changes merged to `dev` since 6.8.5:
- Disable `absolute_redirect` in internal nginx so trailing-slash redirects stay relative (#558)
- Put Galaxy's lib on PYTHONPATH for built-in tools pinned to the image

Per `docs/release-process.md`, this PR carries the `patch` label; merging
triggers the release workflow (version bump, package/publish, tag, and
merge-back to `dev`).

## Test plan
- [x] `linting` and `test` checks pass
- [ ] Maintainer approves the `release` environment deployment gate on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)