### PR TITLE
Release 6.8.7

### DIFF
--- a/galaxy/templates/configmap-post-install.yaml
+++ b/galaxy/templates/configmap-post-install.yaml
@@ -13,7 +13,9 @@ data:
 {{- .Values.postInstallJob.bootstrapConfig | nindent 4 }}
   post-install.sh: |
     #!/bin/bash
-    set -e
+    # pipefail is required: USER_KEY is captured from `abm ... | jq`, so without it a
+    # failing abm is masked by jq's exit 0 and set -e never trips.
+    set -eo pipefail
 
     # Wait for Galaxy to be ready. -f is required: without it curl exits 0 on a 404,
     # so a misrouted URL would satisfy this loop and fail confusingly further down.
@@ -50,8 +52,10 @@ data:
     USER_KEY=$(abm galaxy user create $USERNAME $GALAXY_USER $GALAXY_MASTER_KEY | jq -r .key)
     {{- end }}
     # Without a real user key ABM silently falls back to the master key, which makes
-    # Galaxy return 500 on user-scoped endpoints instead of a usable error.
-    if [ -z "$USER_KEY" ]; then
+    # Galaxy return 500 on user-scoped endpoints instead of a usable error. Treat the
+    # literal "null" as failure too: `jq -r .key` emits it when abm returns a JSON
+    # error object with no .key, and it would otherwise slip past the -z check.
+    if [ -z "$USER_KEY" ] || [ "$USER_KEY" = "null" ]; then
       echo "ERROR: no API key obtained for $GALAXY_USER; cannot bootstrap." >&2
       exit 1
     fi


### PR DESCRIPTION
Release PR: `dev` → `master`, `patch` bump (6.8.6 → 6.8.7).

## Changes

- **Allow HTML uploads** (#567) — sets `check_upload_content: false` in the
  Galaxy config. Without it Galaxy rejects HTML uploads, leaving users unable
  to supply inputs to any tool declaring `format="html"`. Rendering stays safe:
  `sanitize_all_html` serves uploaded HTML as `text/plain`, since an upload job
  is never in `sanitize_allowlist_file`.

## Release checks

- `appVersion` (`26.1.1`) matches the Galaxy image tag in `galaxy/values.yaml`.
- Chart `version` untouched on `dev`; the release workflow bumps it.
- Labeled `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Summary compiled by Claude (Claude Code), working with @afgane.</sub>
