### PR TITLE
Harden post-install user-key capture 

### DIFF
--- a/galaxy/templates/configmap-post-install.yaml
+++ b/galaxy/templates/configmap-post-install.yaml
@@ -13,7 +13,9 @@ data:
 {{- .Values.postInstallJob.bootstrapConfig | nindent 4 }}
   post-install.sh: |
     #!/bin/bash
-    set -e
+    # pipefail is required: USER_KEY is captured from `abm ... | jq`, so without it a
+    # failing abm is masked by jq's exit 0 and set -e never trips.
+    set -eo pipefail
 
     # Wait for Galaxy to be ready. -f is required: without it curl exits 0 on a 404,
     # so a misrouted URL would satisfy this loop and fail confusingly further down.
@@ -50,8 +52,10 @@ data:
     USER_KEY=$(abm galaxy user create $USERNAME $GALAXY_USER $GALAXY_MASTER_KEY | jq -r .key)
     {{- end }}
     # Without a real user key ABM silently falls back to the master key, which makes
-    # Galaxy return 500 on user-scoped endpoints instead of a usable error.
-    if [ -z "$USER_KEY" ]; then
+    # Galaxy return 500 on user-scoped endpoints instead of a usable error. Treat the
+    # literal "null" as failure too: `jq -r .key` emits it when abm returns a JSON
+    # error object with no .key, and it would otherwise slip past the -z check.
+    if [ -z "$USER_KEY" ] || [ "$USER_KEY" = "null" ]; then
       echo "ERROR: no API key obtained for $GALAXY_USER; cannot bootstrap." >&2
       exit 1
     fi


### PR DESCRIPTION
## What

Hardens the post-install job's user-key capture so a failed `abm galaxy user create` can no longer be silently swallowed.

The multi-user path captures the key via a pipe:

```bash
USER_KEY=$(abm galaxy user create $USERNAME $GALAXY_USER $GALAXY_MASTER_KEY | jq -r .key)
```

Two gaps remained even after the URL-prefix fix (#549 / `3b91471`):

1. **No `pipefail`**: with only `set -e`, a failing `abm` in the pipe is masked by `jq`'s exit 0, so the script keeps going.
2. **`jq -r .key` emits the literal string `null`** when `abm` returns a JSON error object with no `.key`. That is non-empty, so it slips past the existing `[ -z "$USER_KEY" ]` guard, and the bootstrap then runs against Galaxy with an invalid key, importing nothing while the Job still reports success.

## Change

`galaxy/templates/configmap-post-install.yaml`:

- `set -e` → `set -eo pipefail`
- Extend the guard: `[ -z "$USER_KEY" ] || [ "$USER_KEY" = "null" ]`

## Context

Surfaced on a deployment running an older chart (pre-#549): the post-install Job exited 0 but created no user and imported nothing, because `abm galaxy user create` hit an un-prefixed URL and 404'd. #549 fixes the prefix cause; this closes the remaining silent-failure path so any future `abm` failure aborts the Job loudly instead of reporting success.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and reviewed by a human.
